### PR TITLE
ci: fix CTO reviewer — post as COMMENT (token cannot APPROVE)

### DIFF
--- a/.github/workflows/cto-review.yml
+++ b/.github/workflows/cto-review.yml
@@ -224,25 +224,22 @@ jobs:
           PY
 
       - name: Post PR review
+        # Always posts as COMMENT — not APPROVE/REQUEST_CHANGES — because the default
+        # GITHUB_TOKEN is not permitted to formally approve PRs without toggling a
+        # repo setting. The verdict is still prominent in the first line of the body
+        # ("## CTO Review — APPROVE|REQUEST_CHANGES|COMMENT"). Human merges, so the
+        # GitHub-native review state isn't load-bearing.
         if: steps.claude.outputs.skipped != '1'
         uses: actions/github-script@v7
-        env:
-          VERDICT: ${{ steps.claude.outputs.verdict }}
         with:
           script: |
             const fs = require('fs');
             const body = fs.readFileSync('/tmp/review-body.md', 'utf8');
-            const verdict = process.env.VERDICT;
-            const eventMap = {
-              'APPROVE': 'APPROVE',
-              'REQUEST_CHANGES': 'REQUEST_CHANGES',
-              'COMMENT': 'COMMENT'
-            };
             await github.rest.pulls.createReview({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.issue.number,
-              event: eventMap[verdict] || 'COMMENT',
+              event: 'COMMENT',
               body,
             });
 


### PR DESCRIPTION
**What changed**

The CTO review workflow was calling `pulls.createReview` with event `APPROVE` / `REQUEST_CHANGES`, which GITHUB_TOKEN is not permitted to do by default. First live run hit: `Unprocessable Entity: GitHub Actions is not permitted to approve pull requests.`

Switched the event to always `COMMENT`. The verdict (APPROVE / REQUEST_CHANGES / COMMENT) is still the first-line heading of the review body, so the human sees it immediately. No repo setting change required on your end.

**Why**

The alternative is toggling `Allow GitHub Actions to create and approve pull requests` in repo settings, which requires four clicks across four repos. The COMMENT approach works out of the box with zero configuration.

**Test plan**

- Merge this PR. The reviewer will re-fire on the next PR against this repo and post a COMMENT successfully.
- The PR Theme PR #2 will get an on-demand re-review after this lands.

Agent-Session: cowork-reviewer-fix-20260414