### PR TITLE
fix: image style suffix empty-string bypass and image cost run_id mis…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
             --extensions=php \
             --ignore=vendor/*,tests/*,node_modules/* \
             --warning-severity=0 \
-            --report=full -s \
+            --report=summary \
             includes/ prautoblogger.php uninstall.php
 
   phpunit:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
             --extensions=php \
             --ignore=vendor/*,tests/*,node_modules/* \
             --warning-severity=0 \
-            --report=summary \
+            --report=full -s \
             includes/ prautoblogger.php uninstall.php
 
   phpunit:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to PRAutoBlogger will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Semantic Versioning](https://semver.org/).
 
+## [0.12.2] — 2026-04-24
+
+### Fixed
+- **Image style suffix empty-string bypass** — `get_option()` for `prautoblogger_image_style_suffix` only returns the default constant when the key is absent from `wp_options`; an empty string stored in the DB returns `''`, bypassing fallback entirely. Root cause of post #675 rendering photorealistically instead of as a newspaper comic. Fixed all three call sites in `class-image-prompt-builder.php` (lines 85, 107, 272) by extracting a private helper `get_style_suffix()` that treats both absent AND empty string as "use default".
+
+- **Image cost logged under wrong run_id** — `class-image-pipeline.php` created a fresh cost tracker when invoked without an argument, so image costs were logged under a different `run_id` than the article's other stages. Cost breakdowns aggregating by `run_id` silently excluded the image line item. Fixed by threading the article worker's cost tracker through `PRAutoBlogger_Publisher` and `PRAutoBlogger_Post_Assembler::attach_generated_images()` to the image pipeline constructor. Image costs now share the same `run_id` as analysis, draft, review, and llm_research stages.
+
+
 ## [0.12.1] — 2026-04-23
 
 ### Fixed

--- a/includes/core/class-article-worker.php
+++ b/includes/core/class-article-worker.php
@@ -138,13 +138,13 @@ class PRAutoBlogger_Article_Worker {
 				: $content;
 
 			if ( $auto_publish ) {
-				$publisher->publish( $final, $idea, $review, $run_id );
+				$publisher->publish( $final, $idea, $review, $run_id, $this->cost_tracker );
 				++$result['published'];
 			} else {
-				$publisher->save_as_draft( $final, $idea, $review, $run_id );
+				$publisher->save_as_draft( $final, $idea, $review, $run_id, $this->cost_tracker );
 			}
 		} else {
-			$publisher->save_as_draft( $content, $idea, $review, $run_id );
+			$publisher->save_as_draft( $content, $idea, $review, $run_id, $this->cost_tracker );
 			++$result['rejected'];
 			PRAutoBlogger_Logger::instance()->info(
 				'Article rejected by editor: ' . $idea->get_topic(),

--- a/includes/core/class-image-prompt-builder.php
+++ b/includes/core/class-image-prompt-builder.php
@@ -82,7 +82,7 @@ PROMPT;
 
 		$parsed = $this->rewrite_via_llm( $title, $first_para );
 
-		$style_suffix = get_option( 'prautoblogger_image_style_suffix', PRAUTOBLOGGER_DEFAULT_IMAGE_STYLE_SUFFIX );
+		$style_suffix = $this->get_style_suffix();
 
 		return array(
 			'prompt'  => trim( $parsed['scene'] . ' ' . $style_suffix ),
@@ -104,7 +104,7 @@ PROMPT;
 
 		$parsed = $this->rewrite_via_llm( $title, $context );
 
-		$style_suffix = get_option( 'prautoblogger_image_style_suffix', PRAUTOBLOGGER_DEFAULT_IMAGE_STYLE_SUFFIX );
+		$style_suffix = $this->get_style_suffix();
 
 		return array(
 			'prompt'  => trim( $parsed['scene'] . ' ' . $style_suffix ),
@@ -269,7 +269,7 @@ PROMPT;
 	 */
 	public function build_fallback_prompt( string $title ): array {
 		$parsed       = $this->synthesize_visual_concepts_fallback( $title, '' );
-		$style_suffix = get_option( 'prautoblogger_image_style_suffix', PRAUTOBLOGGER_DEFAULT_IMAGE_STYLE_SUFFIX );
+		$style_suffix = $this->get_style_suffix();
 		return array(
 			'prompt'  => trim( $parsed['scene'] . ' ' . $style_suffix ),
 			'caption' => $parsed['caption'],
@@ -311,4 +311,21 @@ PROMPT;
 		$override = (string) get_option( 'prautoblogger_image_prompt_instructions', '' );
 		return '' !== trim( $override ) ? $override : self::REWRITER_SYSTEM_PROMPT;
 	}
+
+	/**
+	 * Get image style suffix with empty-string safeguard.
+	 * 
+	 * Treats both absent and empty string as "use default" to prevent
+	 * silent style loss if the admin settings field is saved empty.
+	 *
+	 * @return string The style suffix with safe fallback.
+	 */
+	private function get_style_suffix(): string {
+		$style_suffix = (string) get_option( 'prautoblogger_image_style_suffix', '' );
+		if ( '' === trim( $style_suffix ) ) {
+			$style_suffix = PRAUTOBLOGGER_DEFAULT_IMAGE_STYLE_SUFFIX;
+		}
+		return $style_suffix;
+	}
+
 }

--- a/includes/core/class-image-prompt-builder.php
+++ b/includes/core/class-image-prompt-builder.php
@@ -314,7 +314,7 @@ PROMPT;
 
 	/**
 	 * Get image style suffix with empty-string safeguard.
-	 * 
+	 *
 	 * Treats both absent and empty string as "use default" to prevent
 	 * silent style loss if the admin settings field is saved empty.
 	 *
@@ -327,5 +327,5 @@ PROMPT;
 		}
 		return $style_suffix;
 	}
-
 }
+

--- a/includes/core/class-image-prompt-builder.php
+++ b/includes/core/class-image-prompt-builder.php
@@ -328,4 +328,3 @@ PROMPT;
 		return $style_suffix;
 	}
 }
-

--- a/includes/core/class-post-assembler.php
+++ b/includes/core/class-post-assembler.php
@@ -232,11 +232,12 @@ class PRAutoBlogger_Post_Assembler {
 	 * Generate and attach images to a published post.
 	 * Non-blocking — logs errors but doesn't re-throw since the post is already created.
 	 *
-	 * @param int                        $post_id   Post ID.
-	 * @param PRAutoBlogger_Article_Idea $idea      Article idea (contains source IDs).
-	 * @param array                      $post_data Post data array (for article content).
+	 * @param int                        $post_id      Post ID.
+	 * @param PRAutoBlogger_Article_Idea $idea         Article idea (contains source IDs).
+	 * @param array                      $post_data    Post data array (for article content).
+	 * @param ?PRAutoBlogger_Cost_Tracker $cost_tracker Optional cost tracker for image generation cost logging.
 	 */
-	public static function attach_generated_images( int $post_id, PRAutoBlogger_Article_Idea $idea, array $post_data ): void {
+	public static function attach_generated_images( int $post_id, PRAutoBlogger_Article_Idea $idea, array $post_data, ?PRAutoBlogger_Cost_Tracker $cost_tracker = null ): void {
 		// Fetch the original Reddit source data for Image B's source-driven prompt.
 		// The idea's source_ids point to rows in the source_data table collected
 		// during the pipeline's collection step.
@@ -247,7 +248,7 @@ class PRAutoBlogger_Post_Assembler {
 			// internally, immediately after each image generates. This
 			// ensures attachment persists even if the process times out
 			// before this method returns.
-			$result = ( new PRAutoBlogger_Image_Pipeline() )->generate_and_attach_images( $post_id, $post_data, $source_data );
+			$result = ( new PRAutoBlogger_Image_Pipeline( null, $cost_tracker ) )->generate_and_attach_images( $post_id, $post_data, $source_data );
 
 			if ( ! empty( $result['errors'] ) ) {
 				foreach ( $result['errors'] as $error ) {

--- a/includes/core/class-publisher.php
+++ b/includes/core/class-publisher.php
@@ -35,9 +35,10 @@ class PRAutoBlogger_Publisher {
 		string $content,
 		PRAutoBlogger_Article_Idea $idea,
 		PRAutoBlogger_Editorial_Review $review,
-		?string $run_id = null
+		?string $run_id = null,
+		?PRAutoBlogger_Cost_Tracker $cost_tracker = null
 	): int {
-		return $this->create_post( $content, $idea, $review, 'publish', $run_id );
+		return $this->create_post( $content, $idea, $review, 'publish', $run_id, $cost_tracker );
 	}
 
 	/**
@@ -54,9 +55,10 @@ class PRAutoBlogger_Publisher {
 		string $content,
 		PRAutoBlogger_Article_Idea $idea,
 		PRAutoBlogger_Editorial_Review $review,
-		?string $run_id = null
+		?string $run_id = null,
+		?PRAutoBlogger_Cost_Tracker $cost_tracker = null
 	): int {
-		return $this->create_post( $content, $idea, $review, 'draft', $run_id );
+		return $this->create_post( $content, $idea, $review, 'draft', $run_id, $cost_tracker );
 	}
 
 	/**
@@ -75,7 +77,8 @@ class PRAutoBlogger_Publisher {
 		PRAutoBlogger_Article_Idea $idea,
 		PRAutoBlogger_Editorial_Review $review,
 		string $post_status,
-		?string $run_id = null
+		?string $run_id = null,
+		?PRAutoBlogger_Cost_Tracker $cost_tracker = null
 	): int {
 		// Clean LLM artifacts, then inject peptide hyperlinks deterministically
 		// before the content enters WordPress. Peptide linker no-ops gracefully
@@ -106,7 +109,7 @@ class PRAutoBlogger_Publisher {
 		PRAutoBlogger_Post_Assembler::link_generation_logs( $post_id, $run_id );
 
 		if ( 'publish' === $post_status ) {
-			PRAutoBlogger_Post_Assembler::attach_generated_images( $post_id, $idea, $post_data );
+			PRAutoBlogger_Post_Assembler::attach_generated_images( $post_id, $idea, $post_data, $cost_tracker );
 		}
 
 		PRAutoBlogger_Logger::instance()->info(

--- a/includes/core/class-publisher.php
+++ b/includes/core/class-publisher.php
@@ -28,6 +28,7 @@ class PRAutoBlogger_Publisher {
 	 * @param PRAutoBlogger_Article_Idea      $idea    The original article idea.
 	 * @param PRAutoBlogger_Editorial_Review  $review  The editor's review.
 	 * @param string|null                   $run_id  Pipeline run ID for log linking.
+	 * @param ?PRAutoBlogger_Cost_Tracker $cost_tracker Optional cost tracker for image generation cost logging.
 	 * @return int The created post ID.
 	 * @throws \RuntimeException If post creation fails.
 	 */
@@ -48,6 +49,7 @@ class PRAutoBlogger_Publisher {
 	 * @param PRAutoBlogger_Article_Idea      $idea    The original article idea.
 	 * @param PRAutoBlogger_Editorial_Review  $review  The editor's review with rejection notes.
 	 * @param string|null                   $run_id  Pipeline run ID for log linking.
+	 * @param ?PRAutoBlogger_Cost_Tracker $cost_tracker Optional cost tracker for image generation cost logging.
 	 * @return int The created post ID.
 	 * @throws \RuntimeException If post creation fails.
 	 */

--- a/prautoblogger.php
+++ b/prautoblogger.php
@@ -9,7 +9,7 @@
  * Plugin Name:       PRAutoBlogger
  * Plugin URI:        https://peptiderepo.com/prautoblogger
  * Description:       Monitors social media for trending topics, generates SEO-friendly blog posts using AI, and publishes them on a daily schedule with full cost tracking and self-improvement metrics.
- * Version:           0.12.1
+ * Version:           0.12.2
  * Requires at least: 6.0
  * Requires PHP:      7.4
  * Author:            PeptideRepo
@@ -35,7 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 | Defined here so every file in the plugin can reference paths, versions,
 | and limits without magic strings.
 */
-define( 'PRAUTOBLOGGER_VERSION', '0.12.1' );
+define( 'PRAUTOBLOGGER_VERSION', '0.12.2' );
 define( 'PRAUTOBLOGGER_DB_VERSION', '1.1.0' );
 define( 'PRAUTOBLOGGER_PLUGIN_FILE', __FILE__ );
 define( 'PRAUTOBLOGGER_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );


### PR DESCRIPTION
## Bug 1: Image Style Suffix Empty-String Bypass

Root cause: `get_option()` for `prautoblogger_image_style_suffix` returns empty string from DB instead of default constant. An empty string stored in `wp_options` bypasses the fallback entirely.

- Fixed all three call sites in `class-image-prompt-builder.php` (lines 85, 107, 272)
- - Extracted private helper `get_style_suffix()` that treats both absent AND empty string as "use default"
- - Root cause of post #675 rendering photorealistically instead of newspaper comic
## Bug 2: Image Cost Logged Under Wrong run_id

Root cause: `class-image-pipeline.php` creates fresh cost tracker when invoked without argument, so image costs logged under different `run_id` than article's other stages.

- Image costs silently excluded from cost breakdowns aggregating by `run_id`
- - Fixed by threading article worker's cost tracker through Publisher to image pipeline
- - Modified `Publisher::publish()`, `Publisher::save_as_draft()`, `Post_Assembler::attach_generated_images()`
- - Updated `Article_Worker` to pass cost tracker to publisher methods
- - Image costs now share same `run_id` as analysis, draft, review, and llm_research stages
## Changes
- Bumped version 0.12.1 -> 0.12.2
- - Updated CHANGELOG.md with detailed fix descriptions