### PR TITLE
fix: expand Runware pricing whitelist to all 15 registry models (v0.14.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to PRAutoBlogger will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Semantic Versioning](https://semver.org/).
 
+## [0.14.0] - 2026-04-26
+
+### Fixed
+- Runware image generation now correctly uses the admin-selected model instead
+  of silently falling back to FLUX.1 schnell (runware:100@1) for all non-schnell
+  and non-dev selections. Root cause: `class-runware-image-pricing.php` only
+  had 2 models in its `COST_PER_IMAGE` whitelist (schnell + dev), but the
+  image model registry was expanded to 15 Runware models in v0.13.8 without a
+  matching update to the pricing class. Any model ID not in the whitelist caused
+  `resolve_model()` to fall back to schnell, so every Stable Diffusion, FLUX.2,
+  HiDream, TwinFlow, Z-Image, Qwen-Image, Krea, and GLM-Image selection was
+  silently downgraded.
+- Added all 15 Runware model IDs to `COST_PER_IMAGE` and `DEFAULT_STEPS` with
+  correct per-image costs and step counts sourced from runware.ai/pricing (April 2026).
+- Added `@see` cross-reference to `class-image-model-registry.php` in pricing
+  class docblock to prevent future drift.
+
 ## [0.13.9] - 2026-04-26
 
 ### Fixed

--- a/includes/providers/class-runware-image-pricing.php
+++ b/includes/providers/class-runware-image-pricing.php
@@ -6,44 +6,86 @@ declare(strict_types=1);
  *
  * Pricing + model-id resolution helpers for the Runware image provider.
  *
- * Each Runware FLUX model has a flat per-image cost sourced from
+ * Each Runware model has a flat per-image cost sourced from
  * runware.ai/pricing (April 2026). Unlike OpenRouter models, Runware
  * prices scale slightly with steps — the quoted rate here assumes the
- * provider's default step count (4 for schnell, 28 for dev).
+ * provider's default step count for each model.
  *
  * Triggered by: PRAutoBlogger_Runware_Image_Provider, PRAutoBlogger_Runware_Image_Batch.
  * Dependencies: None — pure calculation + option reads.
  *
  * @see class-runware-image-provider.php — Primary caller.
  * @see class-open-router-image-pricing.php — Sibling pattern for OpenRouter.
+ * @see admin/class-image-model-registry.php — Source of truth for model list; keep in sync.
  */
 class PRAutoBlogger_Runware_Image_Pricing {
 
 	/**
 	 * Flat per-image cost (USD) for each supported Runware model, April 2026.
-	 * Update here when Runware reprices or new models launch.
+	 * Update here when Runware reprices or new models launch. Must stay in
+	 * sync with the model list in PRAutoBlogger_Image_Model_Registry — any
+	 * model listed there that is absent here will silently fall back to schnell.
 	 *
-	 * Runware model IDs use `family:variant@version` form. The two FLUX
-	 * variants we support are the CEO-sanctioned defaults.
+	 * Runware model IDs use `family:variant@version` form.
 	 *
 	 * @var array<string, float>
 	 */
 	private const COST_PER_IMAGE = array(
-		// FLUX.1 schnell — 4-step distilled. Our new default (2026-04-21).
-		'runware:100@1' => 0.0006,
-		// FLUX.1 dev — 28-step full model. Higher fidelity, ~30x cost.
-		'runware:101@1' => 0.02,
+		// FLUX.1 schnell — 4-step distilled. Default (2026-04-21).
+		'runware:100@1'                => 0.0006,
+		// TwinFlow Z-Image-Turbo — fast text-to-image, same cost as schnell.
+		'runware:twinflow-z-image-turbo@0' => 0.0006,
+		// FLUX.2 klein 4B — newer architecture at schnell price.
+		'runware:400@4'                => 0.0006,
+		// FLUX.2 klein 9B — stronger than schnell, similar cost.
+		'runware:400@2'                => 0.00078,
+		// Stable Diffusion 3 — sharp text, complex scenes.
+		'runware:5@1'                  => 0.0013,
+		// Z-Image Turbo — fast photorealistic generation.
+		'runware:z-image@turbo'        => 0.0013,
+		// HiDream-I1 Fast — low latency, 17B quality.
+		'runware:97@3'                 => 0.0038,
+		// HiDream-I1 Dev — strong prompt alignment.
+		'runware:97@2'                 => 0.0045,
+		// Z-Image — high-quality foundation model.
+		'runware:z-image@0'            => 0.0045,
+		// FLUX.2 dev — controllable open text-to-image.
+		'runware:400@1'                => 0.0051,
+		// Qwen-Image — strong text rendering in generated images.
+		'runware:108@1'                => 0.0058,
+		// HiDream-I1 Full — 17B high-fidelity, LoRA support.
+		'runware:97@1'                 => 0.009,
+		// FLUX.1 Krea dev — photorealistic open-weight generation.
+		'runware:107@1'                => 0.0098,
+		// FLUX.1 dev — 28-step full model. Higher fidelity, ~30x schnell cost.
+		'runware:101@1'                => 0.02,
+		// GLM-Image — hybrid autoregressive+diffusion, excellent text rendering.
+		'runware:glm-image@0'          => 0.0225,
 	);
 
 	/**
 	 * Default number of inference steps per model. Runware bills per image
 	 * at the model's standard step count; custom step counts may alter price.
+	 * Sources: runware.ai/models (April 2026).
 	 *
 	 * @var array<string, int>
 	 */
 	private const DEFAULT_STEPS = array(
-		'runware:100@1' => 4,
-		'runware:101@1' => 28,
+		'runware:100@1'                    => 4,
+		'runware:twinflow-z-image-turbo@0' => 4,
+		'runware:400@4'                    => 20,
+		'runware:400@2'                    => 20,
+		'runware:5@1'                      => 28,
+		'runware:z-image@turbo'            => 4,
+		'runware:97@3'                     => 16,
+		'runware:97@2'                     => 28,
+		'runware:z-image@0'                => 28,
+		'runware:400@1'                    => 28,
+		'runware:108@1'                    => 20,
+		'runware:97@1'                     => 50,
+		'runware:107@1'                    => 28,
+		'runware:101@1'                    => 28,
+		'runware:glm-image@0'              => 30,
 	);
 
 	/**
@@ -77,9 +119,9 @@ class PRAutoBlogger_Runware_Image_Pricing {
 	/**
 	 * Estimate USD cost for a single image at the given model.
 	 *
-	 * Runware FLUX pricing is flat per image at the model's standard step
-	 * count. Width/height are accepted for interface compatibility but do
-	 * not affect cost for the variants we support.
+	 * Runware pricing is flat per image at the model's standard step count.
+	 * Width/height are accepted for interface compatibility but do not affect
+	 * cost for the variants we support.
 	 *
 	 * @param int    $width  Width in pixels (unused for flat pricing).
 	 * @param int    $height Height in pixels (unused for flat pricing).

--- a/prautoblogger.php
+++ b/prautoblogger.php
@@ -9,7 +9,7 @@
  * Plugin Name:       PRAutoBlogger
  * Plugin URI:        https://peptiderepo.com/prautoblogger
  * Description:       Monitors social media for trending topics, generates SEO-friendly blog posts using AI, and publishes them on a daily schedule with full cost tracking and self-improvement metrics.
- * Version:           0.13.9
+ * Version:           0.14.0
  * Requires at least: 6.0
  * Requires PHP:      7.4
  * Author:            PeptideRepo
@@ -35,7 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 | Defined here so every file in the plugin can reference paths, versions,
 | and limits without magic strings.
 */
-define( 'PRAUTOBLOGGER_VERSION', '0.13.9' );
+define( 'PRAUTOBLOGGER_VERSION', '0.14.0' );
 define( 'PRAUTOBLOGGER_DB_VERSION', '1.1.0' );
 define( 'PRAUTOBLOGGER_PLUGIN_FILE', __FILE__ );
 define( 'PRAUTOBLOGGER_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );


### PR DESCRIPTION
## Problem

All Runware model selections except `runware:100@1` (schnell) and `runware:101@1` (dev) were silently falling back to schnell during image generation.

**Root cause:** `class-runware-image-pricing.php` had a `COST_PER_IMAGE` whitelist with only 2 entries. `resolve_model()` falls back to schnell for any ID not in that whitelist. The image model registry was expanded to 15 Runware models in v0.13.8 but the pricing class was never updated to match.

Result: selecting Stable Diffusion 3, FLUX.2, HiDream, TwinFlow, Z-Image, Qwen-Image, Krea dev, or GLM-Image all silently generated schnell images — the admin column showed `runware:100@1` regardless of what was selected.

## Fix

- Added all 15 Runware model IDs to `COST_PER_IMAGE` with costs from runware.ai/pricing (April 2026)
- Added all 15 models to `DEFAULT_STEPS` with step counts appropriate to each architecture
- Added `@see` cross-reference to `class-image-model-registry.php` in the pricing class docblock to flag the sync dependency for future editors

## Files changed

- `includes/providers/class-runware-image-pricing.php` — data-only, no logic changes
- `prautoblogger.php` — version bump to 0.14.0
- `CHANGELOG.md` — entry added