### PR TITLE
ci: fix cto-review ARG_MAX (#110) + restore deploy pipeline

### DIFF
--- a/.github/workflows/cto-review.yml
+++ b/.github/workflows/cto-review.yml
@@ -123,17 +123,18 @@ jobs:
           git fetch origin ${{ github.event.pull_request.base.ref }} --depth=50
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
           HEAD_SHA="${{ github.event.pull_request.head.sha }}"
-          DIFF=$(git diff --no-color "$BASE_SHA" "$HEAD_SHA" | head -c 400000)
+          # Write the diff to a file, not a step output / env var. Passing a
+          # ~400KB diff through the process env (execve argv+envp) exceeds the
+          # runner ARG_MAX and fails the next step with "Argument list too long"
+          # (issue #110). File transport also sidesteps the ~1MB step-output cap.
+          git diff --no-color "$BASE_SHA" "$HEAD_SHA" | head -c 400000 > /tmp/cto-review-diff.txt
           FILES=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
-          SIZE=$(echo -n "$DIFF" | wc -c)
+          SIZE=$(wc -c < /tmp/cto-review-diff.txt)
           {
             echo "size=$SIZE"
             echo "files<<EOF_FILES"
             echo "$FILES"
             echo "EOF_FILES"
-            echo "diff<<EOF_DIFF"
-            echo "$DIFF"
-            echo "EOF_DIFF"
           } >> "$GITHUB_OUTPUT"
 
       - name: Load repo conventions
@@ -161,7 +162,7 @@ jobs:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO_NAME: ${{ github.event.repository.name }}
-          DIFF: ${{ steps.diff.outputs.diff }}
+          DIFF_PATH: /tmp/cto-review-diff.txt
           DIFF_SIZE: ${{ steps.diff.outputs.size }}
           CHANGED_FILES: ${{ steps.diff.outputs.files }}
           CONVENTIONS: ${{ steps.conventions.outputs.content }}
@@ -229,7 +230,9 @@ jobs:
           user_blocks.append(f"**Changed files:**\n```\n{os.environ['CHANGED_FILES']}\n```\n")
           if os.environ.get("CONVENTIONS", "").strip():
               user_blocks.append(f"# Repo CONVENTIONS.md\n{os.environ['CONVENTIONS']}\n")
-          user_blocks.append(f"# Diff\n```diff\n{os.environ['DIFF']}\n```\n")
+          with open(os.environ["DIFF_PATH"], encoding="utf-8", errors="replace") as _df:
+              _diff_text = _df.read()
+          user_blocks.append(f"# Diff\n```diff\n{_diff_text}\n```\n")
           user_message = "\n\n".join(user_blocks)
 
           tools = [{

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,6 @@ jobs:
   smoke:
     name: Smoke tests (staging)
     needs: deploy-staging
-    continue-on-error: true
     uses: peptiderepo/peptide-e2e/.github/workflows/smoke.yml@main
     secrets:
       STAGING_WP_ADMIN_USER: ${{ secrets.STAGING_WP_ADMIN_USER }}


### PR DESCRIPTION
Two CI/workflow fixes. **Does not auto-merge — merging triggers a production deploy, so leaving for CEO greenlight per the deploy approval workflow.**

### 1. Fix `cto-review.yml` ARG_MAX (closes #110)
The multi-model review step received the PR diff via an env var. A ~400KB diff in the process env exceeds the runner's ARG_MAX and the step died with `Argument list too long`, silently skipping AI review on any large/mechanical PR. Now the diff is written to `/tmp/cto-review-diff.txt` and read from there; the 380KB review-size gate is unchanged.

### 2. Restore the deploy pipeline
`deploy.yml`'s `smoke` job (a reusable-workflow `uses:` call) had `continue-on-error: true`, which Actions does not support on `uses:` jobs — it produces a **0-job workflow failure**, which is why every prautoblogger deploy since this landed has failed. Removed it (same fix already in `peptide-repo-core` 69abae3 and the theme). Smoke is not in `deploy-production`'s `needs`, so a failing smoke run stays non-blocking.

Both files validated as parseable YAML. — CTO