### PR TITLE
Pipeline v2 Phase 1 — prompt registry, audit substrate, cost governor, run state machine (v0.18.0)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -126,6 +126,7 @@ prautoblogger/
 │
 ├── includes/
 │   ├── class-prautoblogger.php        # Main orchestrator — registers all hooks, delegates execution
+│   ├── class-pipeline-schema-installer.php # v0.18.0 substrate tables (prompts, run_sources, run_decisions, runs, run_stages)
 │   ├── class-executor.php             # Cron handlers, generation AJAX (start + status), model registry
 │   ├── class-ajax-handlers.php        # Non-generation AJAX: images, models, test connections
 │   ├── class-generation-lock.php      # DB-level atomic mutex for single-writer generation
@@ -171,6 +172,7 @@ prautoblogger/
 │   │   ├── class-image-attacher.php        # Sideload + cost log + variant meta-linking + caption prepend
 │   │   ├── class-image-media-sideloader.php # Imports images into WordPress media library
 │   │   ├── class-cost-tracker.php     # Logs all API costs, enforces budget limits
+│   │   ├── class-stage-display-map.php # Stage vocabulary: labels + default roles + prompt keys (old + new + image stages)
 │   │   ├── class-logger.php           # Structured logging singleton (error/warning/info/debug)
 │   │   ├── class-article-worker.php   # Single-article generation (content + edit + publish)
 │   │   ├── class-pipeline-runner.php  # Orchestrates pipeline; chains per-article cron jobs
@@ -379,7 +381,7 @@ All tables use `$wpdb->prefix` + `prautoblogger_` prefix.
 | id                | BIGINT UNSIGNED   | Auto-increment PK                             |
 | post_id           | BIGINT UNSIGNED   | WordPress post ID (nullable, set after publish)|
 | run_id            | VARCHAR(36)       | UUID linking all entries from one pipeline run |
-| stage             | VARCHAR(50)       | 'analysis', 'outline', 'draft', 'edit', 'review' |
+| stage             | VARCHAR(50)       | See "Stage vocabulary" below. Canonical edit-stage name is **'polish'** (this doc previously said 'edit'; the code always wrote 'polish') |
 | provider          | VARCHAR(50)       | 'openrouter'                                  |
 | model             | VARCHAR(100)      | Model identifier used                         |
 | prompt_tokens     | INT               | Input tokens consumed                         |
@@ -388,12 +390,26 @@ All tables use `$wpdb->prefix` + `prautoblogger_` prefix.
 | request_json      | LONGTEXT          | Full request payload (for debugging)          |
 | response_status   | VARCHAR(20)       | 'success', 'error', 'timeout'                 |
 | error_message     | TEXT              | Error details if failed (nullable)             |
+| agent_role        | VARCHAR(50)       | v0.18.0, nullable. Role that made the call ('writer', 'editor', 'analyst', 'researcher', 'illustrator', …). Historical rows stay NULL |
+| prompt_version    | VARCHAR(20)       | v0.18.0, nullable. Pinned prompt-registry version the call rendered with. Historical rows stay NULL |
 | created_at        | DATETIME          | When the API call was made                    |
 
 - INDEX: `post_id`
 - INDEX: `run_id`
 - INDEX: `created_at`
 - INDEX: `stage`
+
+**Stage vocabulary.** `stage` is a VARCHAR, not a SQL enum; the vocabulary lives in
+`PRAutoBlogger_Stage_Display_Map` (PHP), which renders historical and new values coherently
+and maps each stage to its default agent role + primary prompt-registry key:
+
+- **Historical values (exist on prod):** `analysis`, `outline`, `draft`, `polish`, `review`,
+  `llm_research`, `image_a`, `image_b`, `image_prompt_rewrite`, `opik_eval_judge`.
+  Note: single-pass generation logs its one call as `draft` (no `outline` row — that absence
+  is how single-pass and multi-step runs are told apart in cost reporting).
+- **Pipeline v2 values (new runs may write):** `research`, `curate`, `draft`, `editorial`,
+  `seo`, `publish`.
+- Unknown values render via a humanizing fallback — the audit view never renders blank.
 
 #### `prab_event_log` — Structured application logging
 
@@ -426,6 +442,97 @@ All tables use `$wpdb->prefix` + `prautoblogger_` prefix.
 - INDEX: `post_id`
 - INDEX: `measured_at`
 - INDEX: `composite_score`
+
+#### Pipeline v2 substrate tables (v0.18.0, db 1.2.0)
+
+Real table names use the standard prefix, e.g. `wp_prautoblogger_prompts` (the plan-of-record's
+`prab_*` names are shorthand). Created by `PRAutoBlogger_Pipeline_Schema_Installer`; all are
+dropped on uninstall.
+
+##### `prautoblogger_prompts` — versioned prompt registry
+
+| Column      | Type            | Description                                              |
+|-------------|-----------------|----------------------------------------------------------|
+| id          | BIGINT UNSIGNED | Auto-increment PK                                        |
+| prompt_key  | VARCHAR(64)     | Registry key, e.g. 'content.single_pass' (`key` is reserved SQL) |
+| version     | INT UNSIGNED    | Monotonic per key; **rows are immutable** — edits create new versions |
+| body        | LONGTEXT        | Prompt template; `{{ token }}` placeholders filled at render time |
+| model       | VARCHAR(100)    | Optional model hint (informational in Phase 1)           |
+| params_json | LONGTEXT        | Optional params snapshot (temperature, max_tokens, …)     |
+| author      | VARCHAR(100)    | Who created the version ('seed:v0.18.0', wp user login, agent) |
+| created_at  | DATETIME        | Version creation time                                    |
+| active      | TINYINT(1)      | Exactly one active row per key                           |
+
+- UNIQUE: `prompt_key, version` · INDEX: `prompt_key, active`
+
+##### `prautoblogger_run_sources` — per-run source audit
+
+| Column        | Type         | Description                                  |
+|---------------|--------------|----------------------------------------------|
+| id            | BIGINT UNSIGNED | Auto-increment PK                         |
+| run_id        | VARCHAR(36)  | Pipeline run UUID                            |
+| agent_role    | VARCHAR(50)  | Role that surfaced the source               |
+| source_url    | VARCHAR(500) | Source URL (nullable)                        |
+| doi           | VARCHAR(255) | DOI when known (nullable)                    |
+| kept          | TINYINT(1)   | Keep/discard decision                        |
+| reason        | TEXT         | Why kept or discarded (nullable)             |
+| quality_score | FLOAT        | Source quality weighting (nullable)          |
+| created_at    | DATETIME     | Row creation time                            |
+
+- INDEX: `run_id` — consolidates the old `source_ids_json` + `_prautoblogger_research_sources`
+  scatter for **new** runs; historical runs are not backfilled.
+
+##### `prautoblogger_run_decisions` — per-stage decision audit
+
+| Column         | Type        | Description                                   |
+|----------------|-------------|-----------------------------------------------|
+| id             | BIGINT UNSIGNED | Auto-increment PK                         |
+| run_id         | VARCHAR(36) | Pipeline run UUID                             |
+| stage          | VARCHAR(50) | Stage that decided (see stage vocabulary)     |
+| verdict        | VARCHAR(50) | e.g. 'approved', 'revised', 'rejected', 'halted' |
+| rationale      | TEXT        | Decision rationale (nullable)                 |
+| citation_score | FLOAT       | Nullable until the Phase-2 editorial loop computes it |
+| created_at     | DATETIME    | Row creation time                             |
+
+- INDEX: `run_id`
+
+##### `prautoblogger_runs` — run ledger + lifecycle
+
+| Column              | Type          | Description                                 |
+|---------------------|---------------|---------------------------------------------|
+| run_id              | VARCHAR(36)   | PK — pipeline run UUID                      |
+| status              | VARCHAR(20)   | pending / running / done / failed / halted  |
+| ceiling_usd         | DECIMAL(10,6) | Per-run cost ceiling snapshotted at run start |
+| reserved_usd        | DECIMAL(10,6) | Outstanding reserve-before-call holds       |
+| settled_usd         | DECIMAL(10,6) | Actual settled spend                        |
+| overage_usd         | DECIMAL(10,6) | Amount the breaching reservation exceeded the ceiling by |
+| pinned_prompts_json | LONGTEXT      | Map of prompt_key → version frozen at run start |
+| started_at          | DATETIME      | Run start                                   |
+| updated_at          | DATETIME      | Last ledger/state write                     |
+| finished_at         | DATETIME      | Set on done/failed/halted (nullable)        |
+
+- INDEX: `status` — the Cost_Governor's reserve is a single conditional UPDATE against this
+  row (same atomic discipline as the #10 generation lock), so concurrent `curl_multi`
+  writers cannot slip past the ceiling between check and call.
+
+##### `prautoblogger_run_stages` — per-run per-stage state machine
+
+| Column      | Type            | Description                                        |
+|-------------|-----------------|----------------------------------------------------|
+| id          | BIGINT UNSIGNED | Auto-increment PK                                  |
+| run_id      | VARCHAR(36)     | Pipeline run UUID                                  |
+| stage       | VARCHAR(50)     | Stage name (see stage vocabulary)                  |
+| agent_role  | VARCHAR(50)     | Fan-out dimension for Phase-2 quorum ('' default)  |
+| item_key    | VARCHAR(64)     | Scopes article-level stages within multi-article runs ('' for run-level) |
+| status      | VARCHAR(20)     | pending / running / done / failed / halted         |
+| attempt     | SMALLINT UNSIGNED | Re-entry counter                                 |
+| cost_usd    | DECIMAL(10,6)   | Cost attributed to the stage                       |
+| meta_json   | LONGTEXT        | Stage output snapshot — lets resume reuse a done stage instead of re-charging it (payload pruned on the retention cron) |
+| started_at  | DATETIME        | First entry                                        |
+| updated_at  | DATETIME        | Last transition                                    |
+| finished_at | DATETIME        | Set on done/failed (nullable)                      |
+
+- UNIQUE: `run_id, stage, agent_role, item_key` (the idempotency key) · INDEX: `status, updated_at`
 
 ### WordPress Options (`wp_options`)
 
@@ -668,6 +775,46 @@ Kept here for history. Until v0.8.2 the default image backend was FLUX.1 schnell
 We already use Cloudflare for DNS/CDN on peptiderepo.com, so layering AI Gateway in front of OpenRouter is zero marginal infrastructure. It gives us response caching (meaningful for repeated classification/scoring calls), a unified cost/latency dashboard, rate limiting, and provider fallback — all of which we would otherwise have to build ourselves to satisfy the CTO cost-tracking rules. Kept as an opt-in URL setting (`prautoblogger_ai_gateway_base_url`) so the plugin still works unchanged out of the box and can be bypassed instantly if the gateway misbehaves. The gateway is a transparent OpenRouter-compatible proxy; no new provider class is needed, and the response parsing path (`usage`, `choices[0].message.content`) is unchanged.
 
 ---
+
+### #22: Pipeline v2 Phase 1 substrate (v0.18.0, db 1.2.0, June 2026)
+
+Phase 1 of the CEO-approved pipeline rebuild (plan of record:
+`convo/cpo/threads/2026-06-prautoblogger-pipeline-redesign/03-cto-revised-brief.md`), built
+**on the current pipeline with no behavior change** to the Economy (single-pass) and
+multi-step publish paths. Four subsystems:
+
+1. **Versioned prompt registry** (`prautoblogger_prompts`). All pipeline prompt copy
+   (content/analysis/editor/research + the illustration rewriter prompt and the image Style
+   Template) lives as immutable versioned rows; the hardcoded v0.16.0 texts are seeded as v1
+   and remain the in-code fallback, so a missing/empty table can never fatal — call sites
+   render through `PRAutoBlogger_Prompt_Registry` and fall back to the same constants the
+   seed used (byte-identical output). A run pins the active version of every key at start
+   (`runs.pinned_prompts_json`) and every generation_log row is stamped with the pinned
+   `prompt_version`. The image-composer PR **consumes** the `image.*` keys — it must not
+   grow its own prompt storage. No admin UI in Phase 1; the API supports list/activate/
+   create-version (never mutate) for the Phase-2 Prompts screen.
+2. **Additive audit schema.** `agent_role` + `prompt_version` columns on generation_log;
+   `run_sources` + `run_decisions` child tables; `PRAutoBlogger_Stage_Display_Map` renders
+   historical + image + v2 stage values. `request_json` (and stage output payloads in
+   `run_stages.meta_json`) are nulled after R days — R from the
+   `prautoblogger_request_json_retention_days` setting (default 14), pruned on the existing
+   daily reaper cron.
+3. **Per-run cost governor** (`PRAutoBlogger_Cost_Governor`). Reserve-before-call against the
+   per-run ledger row using a single conditional UPDATE (the #10 atomic-write discipline);
+   estimates come from the #18 pricing chain; `curl_multi` image batches reserve their summed
+   estimate before dispatch; reservations settle to actuals after each response. Breach →
+   run `halted`, overage recorded, un-dispatched work aborted, surfaced on the Review Queue.
+   Ceiling = `prautoblogger_per_run_cost_ceiling_usd` setting (default $0.50, 0 = disabled).
+   The monthly `Cost_Tracker` cap and the Cloudflare AI Gateway (#15) path are unchanged.
+4. **Run state machine + idempotency** (`PRAutoBlogger_Run_State`). Per-run per-stage state
+   (pending/running/done/failed/halted) keyed `run_id + stage + agent_role + item_key`
+   (item_key scopes article-level stages because one run_id spans all N articles of a batch);
+   done stages persist output and are reused on re-entry, never re-charged; post creation is
+   keyed by `_prautoblogger_run_id` + `_prautoblogger_idea_hash` (check-before-insert) so a
+   retried run cannot duplicate a post. `PRAutoBlogger_Run_Reaper` (same daily cron as #19)
+   marks runs stuck `running` > 2× expected stage wall-clock as `failed`; such runs render
+   as **"incomplete"** in audit queries. Quorum logic itself is Phase 2 — the schema just
+   reserves its dimensions.
 
 ### #20: PHPUnit test infrastructure + WordPress-Core PHPCS compliance (v0.10.1)
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -182,6 +182,10 @@ prautoblogger/
 │   │   ├── class-run-state.php        # runs-table ledger + lifecycle row (ceiling/reserved/settled, pins, status)
 │   │   ├── class-cost-governor.php    # Per-run reserve-before-call enforcement (atomic conditional UPDATE)
 │   │   ├── class-cost-ceiling-exception.php # Thrown on ceiling breach (run already halted)
+│   │   ├── class-run-stage-state.php  # Per-run per-stage state machine (idempotent resume, output snapshots)
+│   │   ├── class-run-reaper.php       # Stuck-run sweep + audit-payload retention (rides the #19 cron)
+│   │   ├── class-audit-writer.php     # run_sources / run_decisions insert layer
+│   │   ├── class-pipeline-status.php  # Status-transient + summary helpers (extracted from runner/worker)
 │   │   ├── class-logger.php           # Structured logging singleton (error/warning/info/debug)
 │   │   ├── class-article-worker.php   # Single-article generation (content + edit + publish)
 │   │   ├── class-pipeline-runner.php  # Orchestrates pipeline; chains per-article cron jobs
@@ -563,6 +567,7 @@ All prefixed with `prautoblogger_`:
 | `prautoblogger_target_subreddits`      | JSON array of subreddits to monitor                   |
 | `prautoblogger_monthly_budget_usd`     | Monthly API spend limit in USD                        |
 | `prautoblogger_per_run_cost_ceiling_usd` | v0.18.0 — per-run hard cost ceiling (USD); reserve-before-call enforced; snapshotted onto the runs row at run start; 0 = disabled. Default `PRAUTOBLOGGER_DEFAULT_RUN_CEILING_USD` ($0.50) |
+| `prautoblogger_request_json_retention_days` | v0.18.0 — days before heavy audit payloads (generation_log.request_json, run_stages.meta_json) are NULLed by the daily cleanup cron; 0 = keep forever. Default `PRAUTOBLOGGER_DEFAULT_REQUEST_JSON_RETENTION_DAYS` (14) |
 | `prautoblogger_tone`                   | Content tone (informational, conversational, etc.)    |
 | `prautoblogger_min_word_count`         | Minimum article word count (default: 800)             |
 | `prautoblogger_max_word_count`         | Maximum article word count (default: 2000)            |
@@ -608,6 +613,7 @@ Stored on every PRAutoBlogger-generated post:
 | `_prautoblogger_editor_notes`         | Chief editor's review notes                   |
 | `_prautoblogger_generated_at`         | ISO 8601 timestamp of generation              |
 | `_prautoblogger_research_sources`     | JSON array of source URLs used                |
+| `_prautoblogger_idea_hash`            | v0.18.0 — stable hash of the idea (title|topic); with `_prautoblogger_run_id` forms the post-creation idempotency key |
 | `_prautoblogger_og_image_id`          | Attachment ID of the composed 1200×630 OG variant (v0.17.0; the rebuilt SEO stage emits `og:image` from this — key name frozen) |
 | `_prautoblogger_square_image_id`      | Attachment ID of the composed 1080×1080 square variant (v0.17.0; stored now, no consumer yet) |
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -127,6 +127,7 @@ prautoblogger/
 ├── includes/
 │   ├── class-prautoblogger.php        # Main orchestrator — registers all hooks, delegates execution
 │   ├── class-pipeline-schema-installer.php # v0.18.0 substrate tables (prompts, run_sources, run_decisions, runs, run_stages)
+│   ├── class-migrate-prompt-seed-v0180.php # One-shot v0.18.0 prompt-registry seed migration
 │   ├── class-executor.php             # Cron handlers, generation AJAX (start + status), model registry
 │   ├── class-ajax-handlers.php        # Non-generation AJAX: images, models, test connections
 │   ├── class-generation-lock.php      # DB-level atomic mutex for single-writer generation
@@ -173,6 +174,12 @@ prautoblogger/
 │   │   ├── class-image-media-sideloader.php # Imports images into WordPress media library
 │   │   ├── class-cost-tracker.php     # Logs all API costs, enforces budget limits
 │   │   ├── class-stage-display-map.php # Stage vocabulary: labels + default roles + prompt keys (old + new + image stages)
+│   │   ├── class-prompt-registry.php  # Versioned prompt registry, read side (render, pins, self-healing fallback)
+│   │   ├── class-prompt-registry-writer.php # Registry write side (create version, activate, seed) — versions immutable
+│   │   ├── class-prompt-defaults.php  # Canonical v1 bodies: content.* + analysis.* (seed + fallback single source)
+│   │   ├── class-prompt-defaults-editorial.php # Canonical v1 bodies: editor.* / research.system / image.* (composer seam)
+│   │   ├── class-run-context.php      # Per-process active run id (set by Cost_Tracker::set_run_id)
+│   │   ├── class-run-state.php        # runs-table ledger + lifecycle row (ceiling/reserved/settled, pins, status)
 │   │   ├── class-logger.php           # Structured logging singleton (error/warning/info/debug)
 │   │   ├── class-article-worker.php   # Single-article generation (content + edit + publish)
 │   │   ├── class-pipeline-runner.php  # Orchestrates pipeline; chains per-article cron jobs

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -180,6 +180,8 @@ prautoblogger/
 │   │   ├── class-prompt-defaults-editorial.php # Canonical v1 bodies: editor.* / research.system / image.* (composer seam)
 │   │   ├── class-run-context.php      # Per-process active run id (set by Cost_Tracker::set_run_id)
 │   │   ├── class-run-state.php        # runs-table ledger + lifecycle row (ceiling/reserved/settled, pins, status)
+│   │   ├── class-cost-governor.php    # Per-run reserve-before-call enforcement (atomic conditional UPDATE)
+│   │   ├── class-cost-ceiling-exception.php # Thrown on ceiling breach (run already halted)
 │   │   ├── class-logger.php           # Structured logging singleton (error/warning/info/debug)
 │   │   ├── class-article-worker.php   # Single-article generation (content + edit + publish)
 │   │   ├── class-pipeline-runner.php  # Orchestrates pipeline; chains per-article cron jobs
@@ -560,6 +562,7 @@ All prefixed with `prautoblogger_`:
 | `prautoblogger_niche_description`      | Text description of the site's niche                  |
 | `prautoblogger_target_subreddits`      | JSON array of subreddits to monitor                   |
 | `prautoblogger_monthly_budget_usd`     | Monthly API spend limit in USD                        |
+| `prautoblogger_per_run_cost_ceiling_usd` | v0.18.0 — per-run hard cost ceiling (USD); reserve-before-call enforced; snapshotted onto the runs row at run start; 0 = disabled. Default `PRAUTOBLOGGER_DEFAULT_RUN_CEILING_USD` ($0.50) |
 | `prautoblogger_tone`                   | Content tone (informational, conversational, etc.)    |
 | `prautoblogger_min_word_count`         | Minimum article word count (default: 800)             |
 | `prautoblogger_max_word_count`         | Maximum article word count (default: 2000)            |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,12 @@ behavior change** to the Economy (single-pass) and multi-step publish paths.
   columns when the columns are missing (a cron run right after deploy no longer loses cost
   rows), and the db-version self-heal now also runs on cron requests (`init` +
   `wp_doing_cron()`), not only on `admin_init`.
+- OpenRouter pricing now resolves dated snapshot model IDs returned by the API
+  (e.g. response model `deepseek/deepseek-v4-flash-20260423` for a
+  `deepseek/deepseek-v4-flash` request) to the base model's price before the
+  conservative-estimate fallback applies. Such responses were previously booked
+  at the conservative $10/$30 per-M rate (~30x real cost on flash-tier models) —
+  phantom spend that ate the per-run cost ceiling and the monthly budget gate.
 
 ## [0.17.0] - 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,10 @@ behavior change** to the Economy (single-pass) and multi-step publish paths.
 ### Fixed
 - ARCHITECTURE.md documented the multi-step edit stage as `edit`; the code has always
   written `polish`. Canonicalized to **`polish`** everywhere.
+- Half-migrated-schema hardening: generation_log inserts retry without the new audit
+  columns when the columns are missing (a cron run right after deploy no longer loses cost
+  rows), and the db-version self-heal now also runs on cron requests (`init` +
+  `wp_doing_cron()`), not only on `admin_init`.
 
 ## [0.17.0] - 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,12 +43,27 @@ behavior change** to the Economy (single-pass) and multi-step publish paths.
   sticky lifecycle states) and `PRAutoBlogger_Run_Context` (per-process run id, mirrors the
   Opik trace-context pattern).
 
+- **Per-run cost governor** (`PRAutoBlogger_Cost_Governor`, net-new enforcement — previously
+  only the monthly cap was enforced): every `send_chat_completion()` reserves its worst-case
+  estimate (prompt chars/4 + max_tokens, priced via the #18 chain) against the run ledger
+  with a single atomic conditional UPDATE (the #10 lock discipline) BEFORE dispatch; the
+  image `curl_multi` batch reserves its summed estimate before dispatch; reservations settle
+  to actuals after each response (a failed call releases its hold). Breach → run `halted`
+  (sticky), overage recorded, `Cost_Ceiling_Exception` aborts the call, remaining queued
+  articles abort, and the run is surfaced in a "Halted runs" notice on the Review Queue.
+  New setting **Per-Run Cost Ceiling (USD)** (`prautoblogger_per_run_cost_ceiling_usd`,
+  default `PRAUTOBLOGGER_DEFAULT_RUN_CEILING_USD` = $0.50, snapshotted at run start,
+  0 = disabled). Calls outside a run, the monthly budget, and the Cloudflare AI Gateway
+  path behave exactly as before.
+
 ### Changed
 - `Content_Generator`'s four stage methods now share one `execute_stage()` helper (the Opik
   span + dispatch + cost-log boilerplate was identical); file drops from 301 to ~220 lines.
   No behavior change: same prompts, models, params, span names, stage values.
 - `Cost_Tracker::get_avg_tokens_for_stages()` body moved to `Cost_Reporter` (read-only
   reporting query); the Cost_Tracker method remains as a delegating wrapper.
+- `OpenRouter_Provider`'s API-key fetch + format validation moved to
+  `OpenRouter_Request_Builder::resolve_api_key()` (300-line cap); identical messages/behavior.
 
 ### Fixed
 - ARCHITECTURE.md documented the multi-step edit stage as `edit`; the code has always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,28 @@ behavior change** to the Economy (single-pass) and multi-step publish paths.
   per-stage default agent role and primary prompt-registry key.
 - Uninstall now drops the five substrate tables and clears every plugin cron hook
   (previously only two of eight were cleared).
+- **Versioned prompt registry** (`PRAutoBlogger_Prompt_Registry` + `_Writer`): all pipeline
+  prompt copy — content system/single-pass/outline/draft/polish, analysis system/user,
+  editor system/review, research system, plus the **illustration rewriter prompt and the
+  image Style Template** (the image-composer PR seam) — is seeded as immutable version 1
+  from the v0.16.0 hardcoded texts (`prautoblogger_migrated_prompt_seed_v0180`). One active
+  version per key; changes create new versions, never mutate. Call sites render through the
+  registry with a **byte-identical in-code fallback** when the table is missing/empty
+  (self-healing, no fatals on half-migrated state). No admin UI in Phase 1.
+- **Prompt-version pinning**: `Cost_Tracker::set_run_id()` pins the active version of every
+  key on the run's row; every generation_log row (text and image stages) is stamped with the
+  pinned `prompt_version` plus a stage-derived `agent_role`. Single-pass rows keep stage
+  `draft` and stamp `content.single_pass` explicitly.
+- `PRAutoBlogger_Run_State` (runs-table ledger row: ceiling/reserved/settled/overage, pins,
+  sticky lifecycle states) and `PRAutoBlogger_Run_Context` (per-process run id, mirrors the
+  Opik trace-context pattern).
+
+### Changed
+- `Content_Generator`'s four stage methods now share one `execute_stage()` helper (the Opik
+  span + dispatch + cost-log boilerplate was identical); file drops from 301 to ~220 lines.
+  No behavior change: same prompts, models, params, span names, stage values.
+- `Cost_Tracker::get_avg_tokens_for_stages()` body moved to `Cost_Reporter` (read-only
+  reporting query); the Cost_Tracker method remains as a delegating wrapper.
 
 ### Fixed
 - ARCHITECTURE.md documented the multi-step edit stage as `edit`; the code has always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to PRAutoBlogger will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Semantic Versioning](https://semver.org/).
 
+## [0.18.0] - 2026-06-12
+
+Pipeline v2 — Phase 1 substrate (plan of record: CPO thread
+`2026-06-prautoblogger-pipeline-redesign`, seq 3). Built on the current pipeline with **no
+behavior change** to the Economy (single-pass) and multi-step publish paths.
+
+### Added
+- **Schema v1.2.0** (`prautoblogger_db_version` 1.1.0 → 1.2.0, idempotent dbDelta
+  migrations, self-healing on version mismatch): new tables
+  `wp_prautoblogger_prompts` (versioned prompt registry),
+  `wp_prautoblogger_run_sources` + `wp_prautoblogger_run_decisions` (audit child tables),
+  `wp_prautoblogger_runs` (per-run cost ledger + lifecycle) and
+  `wp_prautoblogger_run_stages` (per-run per-stage state machine, idempotency key
+  `run_id + stage + agent_role + item_key`); additive nullable columns `agent_role` and
+  `prompt_version` on `wp_prautoblogger_generation_log` (historical rows stay valid).
+- `PRAutoBlogger_Stage_Display_Map`: single PHP vocabulary for historical stages
+  (`analysis`, `outline`, `draft`, `polish`, `review`, `llm_research`, `image_a`, `image_b`,
+  `image_prompt_rewrite`, `opik_eval_judge`), Pipeline v2 stages (`research`, `curate`,
+  `draft`, `editorial`, `seo`, `publish`) and a humanizing fallback for unknown values, plus
+  per-stage default agent role and primary prompt-registry key.
+- Uninstall now drops the five substrate tables and clears every plugin cron hook
+  (previously only two of eight were cleared).
+
+### Fixed
+- ARCHITECTURE.md documented the multi-step edit stage as `edit`; the code has always
+  written `polish`. Canonicalized to **`polish`** everywhere.
+
 ## [0.17.0] - 2026-06-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,30 @@ behavior change** to the Economy (single-pass) and multi-step publish paths.
   0 = disabled). Calls outside a run, the monthly budget, and the Cloudflare AI Gateway
   path behave exactly as before.
 
+- **Run state machine + idempotent resume** (`PRAutoBlogger_Run_Stage_State`): per-run
+  per-stage rows keyed `run_id + stage + agent_role + item_key` (item_key scopes
+  article-level stages — one run_id spans all N articles of a batch; agent_role is the
+  Phase-2 quorum dimension, schema-only for now). Done stages snapshot their output and are
+  REUSED on re-entry — never re-run, never re-charged (writer stages via
+  `Content_Generator::set_run_item()`, the editorial review via its stored verdict, a fully
+  published item is skipped outright). **Post creation is keyed by `_prautoblogger_run_id`
+  + new `_prautoblogger_idea_hash` meta (check-before-insert)** so a retried run cannot
+  create a duplicate post. Run-level research/analysis checkpoints ride Pipeline_Runner;
+  completion/failure marks land on the runs row (Executor catch paths, orphan aborts,
+  monthly-budget aborts).
+- **Reaper extension** (`PRAutoBlogger_Run_Reaper`, same daily cron as the #19 research
+  reaper — no new schedule): stages stuck `running` > 2× expected stage wall-clock and runs
+  silent > 2× expected run wall-clock are marked `failed` (filterable expectations); their
+  open stages are reaped; such runs are queryable as **"incomplete"** via
+  `Run_Reaper::incomplete_runs()`. Also enforces **retention**: `request_json` on the
+  generation log and stage output snapshots are NULLed after R days — R from the new
+  **Audit Payload Retention** setting (`prautoblogger_request_json_retention_days`, default
+  `PRAUTOBLOGGER_DEFAULT_REQUEST_JSON_RETENTION_DAYS` = 14, 0 = keep forever).
+- **Audit writes** (`PRAutoBlogger_Audit_Writer`): every reviewed article records its
+  editorial verdict in `run_decisions`; every published article records the sources that
+  fed it in `run_sources` (the source_ids_json / `_prautoblogger_research_sources`
+  consolidation for new runs; no backfill).
+
 ### Changed
 - `Content_Generator`'s four stage methods now share one `execute_stage()` helper (the Opik
   span + dispatch + cost-log boilerplate was identical); file drops from 301 to ~220 lines.
@@ -64,6 +88,9 @@ behavior change** to the Economy (single-pass) and multi-step publish paths.
   reporting query); the Cost_Tracker method remains as a delegating wrapper.
 - `OpenRouter_Provider`'s API-key fetch + format validation moved to
   `OpenRouter_Request_Builder::resolve_api_key()` (300-line cap); identical messages/behavior.
+- Pipeline_Runner's and Article_Worker's duplicated status-transient/summary helpers moved
+  verbatim to the new `PRAutoBlogger_Pipeline_Status` (Pipeline_Runner back under the
+  300-line cap at 271).
 
 ### Fixed
 - ARCHITECTURE.md documented the multi-step edit stage as `edit`; the code has always

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -204,13 +204,18 @@ the uninstall prefix-sweep effective), then cover it in the unit ladder tests.
 
 ## How To: Add a New Pipeline Stage
 
-The writing pipeline is an ordered array of stages. Each stage is a class method on `Content_Generator`.
+Writing stages are methods on `Content_Generator` that delegate to its `execute_stage()`
+helper (Opik span + LLM dispatch + cost log + run-stage state in one place).
 
-1. Add the stage method to `class-content-generator.php`: `protected function stage_{name}(PRAutoBlogger_Content_Request $request): string`
-2. Register the stage in the `get_pipeline_stages()` method for the appropriate mode (single_pass or multi_step)
-3. Each stage receives the accumulated context and returns its output
-4. Each stage logs its cost via `Cost_Tracker::log_api_call()`
-5. If a stage fails after retries, the entire pipeline fails (no partial publishes)
+1. Add the stage method to `class-content-generator.php` and call
+   `$this->execute_stage( $stage, $span_name, $user_prompt, $request, $model, $options )`
+2. Wire it into `generate_multi_step()` (or the relevant mode path)
+3. Add the stage to `PRAutoBlogger_Stage_Display_Map` (label, default agent role, prompt key)
+   and — if it has registry-managed copy — a prompt key in the defaults classes
+4. Cost logging and per-run stage state (idempotent resume, output snapshot) come free from
+   `execute_stage()`; the per-run cost governor guards the call inside the provider
+5. If a stage fails after retries, the entire pipeline fails (no partial publishes); the
+   stage row is failed by the worker's catch-all and the run is swept by Run_Reaper
 
 ---
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -320,6 +320,38 @@ The field renderer, AJAX refresh, model picker JS, and capability filtering are 
 
 Phase 3 will add provider selection; v0.11.0 is OpenRouter-only.
 
+## How To: Change a Pipeline Prompt (v0.18.0+)
+
+Prompt copy is **versioned data**, not code. The bodies live in
+`wp_prautoblogger_prompts` (one ACTIVE version per key); the hardcoded texts in
+`class-prompt-defaults.php` / `class-prompt-defaults-editorial.php` are the canonical v1 seed
+AND the fallback when the table is unavailable — never edit a stored version in place.
+
+1. **Never `UPDATE` a body.** Create a new version and activate it:
+   ```php
+   $v = PRAutoBlogger_Prompt_Registry_Writer::create_version(
+       'content.polish', $new_body, $model, $params, 'your-name', true
+   );
+   ```
+2. **Keys** are dot-namespaced: `content.system`, `content.single_pass`, `content.outline`,
+   `content.draft`, `content.polish`, `analysis.system`, `analysis.user`, `editor.system`,
+   `editor.review`, `research.system`, `image.rewriter_system`, `image.style_template`.
+   The two `image.*` keys are the image-composer seam — coordinate on the convo thread
+   before touching them.
+3. **Tokens** use the `{{ name }}` syntax (exactly one space each side — same convention as
+   the Style Template's `{{ topic_summary }}`). Token VALUES are computed by code
+   (`Content_Prompts`, `Analysis_Prompts`, `Chief_Editor`); a new prompt version may reorder
+   or drop tokens but must not invent new ones without adding the value at the call site.
+4. **Pinning.** A run pins the active version of every key at start
+   (`runs.pinned_prompts_json`, written by `Cost_Tracker::set_run_id()`); every
+   generation_log row is stamped with the pinned `prompt_version`. Activating a new version
+   affects the NEXT run, never a run in flight.
+5. **Call sites** render via `PRAutoBlogger_Prompt_Registry::render( $key, $tokens )` and
+   must keep working when the table is absent (the registry falls back to the defaults
+   automatically — do not add your own fallback).
+6. If you add a key: define the body in the appropriate defaults class, add it to `defs()`,
+   map its stage in `Stage_Display_Map`, and it will seed on the next migration pass.
+
 ## Git Workflow — PR-Gated, Soft-Enforced
 
 This repo is private on GitHub's free plan, which does not support branch protection or rulesets. The review gate is enforced at the agent layer, not server-side. Every agent and human contributor follows these rules; the `.github/workflows/main-push-audit.yml` tripwire opens an audit issue on any direct push to `main` that did not come from a merged PR.

--- a/includes/admin/class-review-queue.php
+++ b/includes/admin/class-review-queue.php
@@ -51,7 +51,20 @@ class PRAutoBlogger_Review_Queue {
 		$paged = isset( $_GET['paged'] ) ? absint( $_GET['paged'] ) : 1;
 		$query = $this->get_pending_posts( $paged );
 
+		// v0.18.0 — runs halted by the per-run cost governor are routed
+		// here for human attention (they may have no draft post to list).
+		$halted_runs = $this->get_halted_runs();
+
 		include PRAUTOBLOGGER_PLUGIN_DIR . 'templates/admin/review-queue.php';
+	}
+
+	/**
+	 * Runs halted by the per-run cost governor, newest first.
+	 *
+	 * @return array<int, array<string, mixed>> Halted run rows (max 10).
+	 */
+	public function get_halted_runs(): array {
+		return PRAutoBlogger_Run_State::halted_runs( 10 );
 	}
 
 	/**

--- a/includes/admin/class-settings-fields-extended.php
+++ b/includes/admin/class-settings-fields-extended.php
@@ -113,6 +113,16 @@ class PRAutoBlogger_Settings_Fields_Extended {
 				'step'        => '0.01',
 				'description' => __( 'Hard stop when reached. 0 = unlimited.', 'prautoblogger' ),
 			),
+			array(
+				'id'          => 'prautoblogger_per_run_cost_ceiling_usd',
+				'label'       => __( 'Per-Run Cost Ceiling (USD)', 'prautoblogger' ),
+				'type'        => 'number',
+				'section'     => 'prautoblogger_schedule',
+				'default'     => PRAUTOBLOGGER_DEFAULT_RUN_CEILING_USD,
+				'min'         => 0,
+				'step'        => '0.01',
+				'description' => __( 'Hard per-run stop: every API call reserves its worst-case cost against this ceiling before dispatch; a breach halts the run and routes it to the Review Queue. Snapshotted at run start. 0 = disabled.', 'prautoblogger' ),
+			),
 
 			// ── Publishing ──────────────────────────────────────────────
 			array(

--- a/includes/admin/class-settings-fields-extended.php
+++ b/includes/admin/class-settings-fields-extended.php
@@ -114,6 +114,16 @@ class PRAutoBlogger_Settings_Fields_Extended {
 				'description' => __( 'Hard stop when reached. 0 = unlimited.', 'prautoblogger' ),
 			),
 			array(
+				'id'          => 'prautoblogger_request_json_retention_days',
+				'label'       => __( 'Audit Payload Retention (days)', 'prautoblogger' ),
+				'type'        => 'number',
+				'section'     => 'prautoblogger_schedule',
+				'default'     => PRAUTOBLOGGER_DEFAULT_REQUEST_JSON_RETENTION_DAYS,
+				'min'         => 0,
+				'step'        => '1',
+				'description' => __( 'Heavy audit payloads (request_json on the generation log, stage output snapshots) are emptied after this many days by the daily cleanup cron. Cost/token rows are kept forever. 0 = keep payloads forever.', 'prautoblogger' ),
+			),
+			array(
 				'id'          => 'prautoblogger_per_run_cost_ceiling_usd',
 				'label'       => __( 'Per-Run Cost Ceiling (USD)', 'prautoblogger' ),
 				'type'        => 'number',

--- a/includes/class-activator.php
+++ b/includes/class-activator.php
@@ -36,9 +36,16 @@ class PRAutoBlogger_Activator {
 		update_option( 'prautoblogger_db_version', PRAUTOBLOGGER_DB_VERSION, false );
 	}
 
-	/** Delegate to `PRAutoBlogger_Schema_Installer::install()` — see that class. */
+	/**
+	 * Delegate to the schema installers — see those classes.
+	 *
+	 * `Schema_Installer` owns the v1.1.0 tables; `Pipeline_Schema_Installer`
+	 * owns the v0.18.0 / db-1.2.0 Pipeline v2 substrate tables. Both are
+	 * dbDelta-idempotent and safe to re-run on any version mismatch.
+	 */
 	private static function create_tables(): void {
 		PRAutoBlogger_Schema_Installer::install();
+		PRAutoBlogger_Pipeline_Schema_Installer::install();
 	}
 
 	/**

--- a/includes/class-activator.php
+++ b/includes/class-activator.php
@@ -31,6 +31,7 @@ class PRAutoBlogger_Activator {
 		self::set_default_options();
 		self::schedule_cron();
 		self::backpopulate_run_id_meta_v081();
+		PRAutoBlogger_Migrate_Prompt_Seed_V0180::run();
 
 		// Store the DB version so we can run migrations on future updates.
 		update_option( 'prautoblogger_db_version', PRAUTOBLOGGER_DB_VERSION, false );

--- a/includes/class-activator.php
+++ b/includes/class-activator.php
@@ -69,6 +69,7 @@ class PRAutoBlogger_Activator {
 			'prautoblogger_target_subreddits'    => '[]',
 			'prautoblogger_monthly_budget_usd'   => 50.00,
 			'prautoblogger_per_run_cost_ceiling_usd' => PRAUTOBLOGGER_DEFAULT_RUN_CEILING_USD,
+			'prautoblogger_request_json_retention_days' => PRAUTOBLOGGER_DEFAULT_REQUEST_JSON_RETENTION_DAYS,
 			'prautoblogger_tone'                 => 'informational',
 			'prautoblogger_min_word_count'       => 800,
 			'prautoblogger_max_word_count'       => 2000,

--- a/includes/class-activator.php
+++ b/includes/class-activator.php
@@ -68,6 +68,7 @@ class PRAutoBlogger_Activator {
 			'prautoblogger_niche_description'    => '',
 			'prautoblogger_target_subreddits'    => '[]',
 			'prautoblogger_monthly_budget_usd'   => 50.00,
+			'prautoblogger_per_run_cost_ceiling_usd' => PRAUTOBLOGGER_DEFAULT_RUN_CEILING_USD,
 			'prautoblogger_tone'                 => 'informational',
 			'prautoblogger_min_word_count'       => 800,
 			'prautoblogger_max_word_count'       => 2000,

--- a/includes/class-executor.php
+++ b/includes/class-executor.php
@@ -53,7 +53,22 @@ class PRAutoBlogger_Executor {
 				sprintf( 'Daily generation %s: %s', get_class( $e ), $e->getMessage() ),
 				'scheduler'
 			);
+			$this->mark_current_run_failed();
 			PRAutoBlogger_Generation_Lock::release();
+		}
+	}
+
+	/**
+	 * Mark this process's run failed after a fatal pipeline error
+	 * (no-op outside a run; a governor-halted run stays halted — final
+	 * states are sticky).
+	 *
+	 * @return void
+	 */
+	private function mark_current_run_failed(): void {
+		$run_id = PRAutoBlogger_Run_Context::current_run_id();
+		if ( null !== $run_id ) {
+			PRAutoBlogger_Run_State::mark_status( $run_id, 'failed' );
 		}
 	}
 
@@ -209,6 +224,7 @@ class PRAutoBlogger_Executor {
 				),
 				self::STATUS_TTL
 			);
+			$this->mark_current_run_failed();
 			PRAutoBlogger_Generation_Lock::release();
 		}
 	}
@@ -286,6 +302,12 @@ class PRAutoBlogger_Executor {
 
 	/** Clean up an orphaned generation run and report error. */
 	private function abort_orphaned_run( string $message ): void {
+		// v0.18.0: the dead run renders as failed/"incomplete" in audit
+		// queries instead of silently lingering as 'running'.
+		$queue = get_option( 'prautoblogger_article_queue' );
+		if ( is_array( $queue ) && ! empty( $queue['run_id'] ) ) {
+			PRAutoBlogger_Run_State::mark_status( (string) $queue['run_id'], 'failed' );
+		}
 		delete_transient( self::STATUS_TRANSIENT );
 		delete_option( 'prautoblogger_article_queue' );
 		PRAutoBlogger_Generation_Lock::release();

--- a/includes/class-migrate-prompt-seed-v0180.php
+++ b/includes/class-migrate-prompt-seed-v0180.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * phpcs:ignore WordPress.Files.FileName.InvalidClassFileName -- class naming convention differs from WordPress standard
+ *
+ * One-shot v0.18.0 migration — seed the versioned prompt registry.
+ *
+ * What: Writes the canonical hardcoded prompt texts (content, analysis,
+ *       editor, research, illustration rewriter, image Style Template)
+ *       into `wp_prautoblogger_prompts` as immutable version 1 and
+ *       activates them. Idempotent twice over: gated by the
+ *       `prautoblogger_migrated_prompt_seed_v0180` flag AND seed_v1()
+ *       itself skips any key that already has rows. The flag is only set
+ *       when the table was actually reachable, so a failed seed
+ *       self-heals on the next activation / version-mismatch pass.
+ *       Standalone class per the Migrate_Remove_Cloudflare_V0100
+ *       precedent (keeps Activator under the 300-line cap).
+ * Who triggers it: PRAutoBlogger_Activator::activate() — on activation and
+ *       on every db-version mismatch.
+ * Dependencies: PRAutoBlogger_Prompt_Registry(_Writer), get_option.
+ *
+ * @see class-activator.php                       — Sole caller.
+ * @see core/class-prompt-registry-writer.php     — seed_v1() implementation.
+ * @see includes/class-migrate-remove-cloudflare-v0100.php — Pattern precedent.
+ */
+class PRAutoBlogger_Migrate_Prompt_Seed_V0180 {
+
+	/** Option flag marking the seed as complete. */
+	private const FLAG = 'prautoblogger_migrated_prompt_seed_v0180';
+
+	/**
+	 * Run the seed once.
+	 *
+	 * Side effects: up to 12 INSERTs into the prompts table, one INFO log
+	 * line, one option write.
+	 *
+	 * @return void
+	 */
+	public static function run(): void {
+		if ( get_option( self::FLAG ) ) {
+			return;
+		}
+		if ( ! PRAutoBlogger_Prompt_Registry::is_available() ) {
+			return; // Table missing — retry on the next migration pass.
+		}
+
+		$seeded = PRAutoBlogger_Prompt_Registry_Writer::seed_v1( 'seed:v0.18.0' );
+
+		if ( class_exists( 'PRAutoBlogger_Logger', false ) ) {
+			PRAutoBlogger_Logger::instance()->info(
+				sprintf( 'Prompt registry seeded: %d key(s) written as v1.', $seeded ),
+				'activator'
+			);
+		}
+
+		update_option( self::FLAG, '1' );
+	}
+}

--- a/includes/class-pipeline-schema-installer.php
+++ b/includes/class-pipeline-schema-installer.php
@@ -1,0 +1,147 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * phpcs:ignore WordPress.Files.FileName.InvalidClassFileName -- class naming convention differs from WordPress standard
+ *
+ * Creates / updates the Pipeline v2 substrate tables via `dbDelta` (db 1.2.0).
+ *
+ * What: Owns the five v0.18.0 substrate tables — the versioned prompt
+ *       registry (`prompts`), the audit child tables (`run_sources`,
+ *       `run_decisions`), and the run ledger / state machine tables
+ *       (`runs`, `run_stages`). Kept separate from the original
+ *       PRAutoBlogger_Schema_Installer so both classes stay under the
+ *       300-line cap and the v1.1.0 schema remains byte-stable.
+ * Who triggers it: PRAutoBlogger_Activator::activate() — on activation and
+ *       on every `prautoblogger_db_version` mismatch (self-healing
+ *       auto-migration via PRAutoBlogger::on_check_db_version()).
+ * Dependencies: WordPress $wpdb, dbDelta() from wp-admin/includes/upgrade.php.
+ *
+ * @see class-schema-installer.php      — v1.1.0 tables (source data, logs, scores).
+ * @see class-activator.php             — Sole caller.
+ * @see core/class-prompt-registry.php  — Reads/writes the prompts table.
+ * @see core/class-run-state.php        — Reads/writes runs + run_stages.
+ * @see ARCHITECTURE.md                 — Database schema section documents each table.
+ */
+class PRAutoBlogger_Pipeline_Schema_Installer {
+
+	/**
+	 * Create (or upgrade) the Pipeline v2 substrate tables.
+	 *
+	 * `dbDelta` is idempotent: it creates missing tables, adds missing
+	 * columns and indexes, and never drops anything — matching the
+	 * plugin's forward-only schema policy. Safe to re-run on every
+	 * version mismatch.
+	 *
+	 * Side effects: up to five CREATE TABLE / ALTER TABLE statements.
+	 *
+	 * @return void
+	 */
+	public static function install(): void {
+		global $wpdb;
+
+		$charset_collate = $wpdb->get_charset_collate();
+		$prefix          = $wpdb->prefix . 'prautoblogger_';
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+		// Versioned prompt registry. Versions are immutable: writes create
+		// new (prompt_key, version) rows; exactly one row per key has
+		// active = 1. `prompt_key` (not `key`) because KEY is reserved SQL.
+		$sql_prompts = "CREATE TABLE {$prefix}prompts (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			prompt_key VARCHAR(64) NOT NULL,
+			version INT UNSIGNED NOT NULL DEFAULT 1,
+			body LONGTEXT NOT NULL,
+			model VARCHAR(100) DEFAULT NULL,
+			params_json LONGTEXT DEFAULT NULL,
+			author VARCHAR(100) NOT NULL DEFAULT '',
+			created_at DATETIME NOT NULL,
+			active TINYINT(1) NOT NULL DEFAULT 0,
+			PRIMARY KEY (id),
+			UNIQUE KEY key_version (prompt_key, version),
+			KEY key_active (prompt_key, active)
+		) {$charset_collate};";
+
+		// Research-source audit rows: one row per source a run considered,
+		// with the keep/discard decision. Consolidates the old
+		// source_ids_json + _prautoblogger_research_sources scatter for
+		// new runs (no backfill of historical runs).
+		$sql_run_sources = "CREATE TABLE {$prefix}run_sources (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			run_id VARCHAR(36) NOT NULL,
+			agent_role VARCHAR(50) NOT NULL DEFAULT '',
+			source_url VARCHAR(500) DEFAULT NULL,
+			doi VARCHAR(255) DEFAULT NULL,
+			kept TINYINT(1) NOT NULL DEFAULT 0,
+			reason TEXT DEFAULT NULL,
+			quality_score FLOAT DEFAULT NULL,
+			created_at DATETIME NOT NULL,
+			PRIMARY KEY (id),
+			KEY run_id (run_id)
+		) {$charset_collate};";
+
+		// Stage-decision audit rows: verdict + rationale per pipeline
+		// stage. citation_score is nullable until the Phase-2 editorial
+		// loop computes it.
+		$sql_run_decisions = "CREATE TABLE {$prefix}run_decisions (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			run_id VARCHAR(36) NOT NULL,
+			stage VARCHAR(50) NOT NULL,
+			verdict VARCHAR(50) NOT NULL,
+			rationale TEXT DEFAULT NULL,
+			citation_score FLOAT DEFAULT NULL,
+			created_at DATETIME NOT NULL,
+			PRIMARY KEY (id),
+			KEY run_id (run_id)
+		) {$charset_collate};";
+
+		// Per-run ledger + lifecycle row. reserved/settled/ceiling drive the
+		// Cost_Governor's atomic reserve-before-call check; pinned_prompts_json
+		// freezes the prompt versions a run uses at start; status feeds the
+		// run state machine (pending|running|done|failed|halted).
+		$sql_runs = "CREATE TABLE {$prefix}runs (
+			run_id VARCHAR(36) NOT NULL,
+			status VARCHAR(20) NOT NULL DEFAULT 'pending',
+			ceiling_usd DECIMAL(10,6) NOT NULL DEFAULT 0,
+			reserved_usd DECIMAL(10,6) NOT NULL DEFAULT 0,
+			settled_usd DECIMAL(10,6) NOT NULL DEFAULT 0,
+			overage_usd DECIMAL(10,6) NOT NULL DEFAULT 0,
+			pinned_prompts_json LONGTEXT DEFAULT NULL,
+			started_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			finished_at DATETIME DEFAULT NULL,
+			PRIMARY KEY (run_id),
+			KEY status (status)
+		) {$charset_collate};";
+
+		// Per-run per-stage state rows. The idempotency key is
+		// (run_id, stage, agent_role, item_key): agent_role is the Phase-2
+		// fan-out dimension (quorum members), item_key scopes article-level
+		// stages within multi-article runs ('' for run-level stages).
+		// meta_json holds the stage output for resume-without-recharge.
+		$sql_run_stages = "CREATE TABLE {$prefix}run_stages (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			run_id VARCHAR(36) NOT NULL,
+			stage VARCHAR(50) NOT NULL,
+			agent_role VARCHAR(50) NOT NULL DEFAULT '',
+			item_key VARCHAR(64) NOT NULL DEFAULT '',
+			status VARCHAR(20) NOT NULL DEFAULT 'pending',
+			attempt SMALLINT UNSIGNED NOT NULL DEFAULT 1,
+			cost_usd DECIMAL(10,6) NOT NULL DEFAULT 0,
+			meta_json LONGTEXT DEFAULT NULL,
+			started_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			finished_at DATETIME DEFAULT NULL,
+			PRIMARY KEY (id),
+			UNIQUE KEY run_stage_role_item (run_id, stage, agent_role, item_key),
+			KEY status_updated (status, updated_at)
+		) {$charset_collate};";
+
+		dbDelta( $sql_prompts );
+		dbDelta( $sql_run_sources );
+		dbDelta( $sql_run_decisions );
+		dbDelta( $sql_runs );
+		dbDelta( $sql_run_stages );
+	}
+}

--- a/includes/class-prautoblogger.php
+++ b/includes/class-prautoblogger.php
@@ -46,6 +46,10 @@ class PRAutoBlogger {
 		$this->ajax_handlers = new PRAutoBlogger_Ajax_Handlers( $this->executor->get_model_registry() );
 
 		add_action( 'admin_init', array( $this, 'on_check_db_version' ) );
+		// v0.18.0: cron requests must also self-heal the schema — after a
+		// deploy, scheduled generation can run before any admin page load,
+		// and new-column inserts would silently fail on the old schema.
+		add_action( 'init', array( $this, 'on_check_db_version_for_cron' ) );
 		add_filter( 'cron_schedules', array( $this, 'filter_add_cron_schedules' ) );
 
 		if ( is_admin() ) {
@@ -303,6 +307,21 @@ class PRAutoBlogger {
 				}
 			}
 			update_option( 'prautoblogger_migrated_enc_prefix', '1' );
+		}
+	}
+
+	/**
+	 * Run the db-version check on cron requests (admin_init never fires
+	 * there). Gated to wp_doing_cron() so normal frontend requests pay
+	 * nothing beyond one autoloaded option read.
+	 *
+	 * Side effects: may run the same migrations as on_check_db_version().
+	 *
+	 * @return void
+	 */
+	public function on_check_db_version_for_cron(): void {
+		if ( function_exists( 'wp_doing_cron' ) && wp_doing_cron() ) {
+			$this->on_check_db_version();
 		}
 	}
 

--- a/includes/class-prautoblogger.php
+++ b/includes/class-prautoblogger.php
@@ -150,6 +150,10 @@ class PRAutoBlogger {
 		// pipeline dies before amortize_research_costs runs).
 		add_action( 'prautoblogger_reap_orphan_research_rows', array( 'PRAutoBlogger_Research_Reaper', 'on_cron' ) );
 
+		// v0.18.0: stuck-run sweep + audit-payload retention rides the SAME
+		// existing daily cron (no new schedule). See class-run-reaper.php.
+		add_action( 'prautoblogger_reap_orphan_research_rows', array( 'PRAutoBlogger_Run_Reaper', 'on_cron' ) );
+
 		// v0.8.1: WP-CLI manual trigger for the reaper. Only registers when
 		// WP-CLI is present; no-op in normal HTTP requests.
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {

--- a/includes/class-schema-installer.php
+++ b/includes/class-schema-installer.php
@@ -77,6 +77,9 @@ class PRAutoBlogger_Schema_Installer {
 		// Generation log — every API call with cost tracking. `run_id`
 		// groups all entries from a single pipeline execution so
 		// `link_generation_logs()` can accurately attribute costs to a post.
+		// v0.18.0 adds the nullable audit columns `agent_role` and
+		// `prompt_version` (dbDelta adds them additively on upgrade;
+		// historical rows stay valid with NULL).
 		$sql_generation_log = "CREATE TABLE {$prefix}generation_log (
 			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
 			post_id BIGINT UNSIGNED DEFAULT NULL,
@@ -90,6 +93,8 @@ class PRAutoBlogger_Schema_Installer {
 			request_json LONGTEXT DEFAULT NULL,
 			response_status VARCHAR(20) NOT NULL DEFAULT 'success',
 			error_message TEXT DEFAULT NULL,
+			agent_role VARCHAR(50) DEFAULT NULL,
+			prompt_version VARCHAR(20) DEFAULT NULL,
 			created_at DATETIME NOT NULL,
 			PRIMARY KEY (id),
 			KEY post_id (post_id),

--- a/includes/core/class-analysis-prompts.php
+++ b/includes/core/class-analysis-prompts.php
@@ -9,7 +9,8 @@ declare(strict_types=1);
  * What: Builds system and user prompts for source-data analysis, including
  *       past-performance context for self-improvement feedback loops.
  * Who calls it: PRAutoBlogger_Content_Analyzer::analyze_recent_data().
- * Dependencies: WordPress $wpdb (for performance lookup), no external APIs.
+ * Dependencies: PRAutoBlogger_Prompt_Registry (versioned prompt bodies),
+ *               WordPress $wpdb (for performance lookup), no external APIs.
  *
  * @see core/class-content-analyzer.php — Orchestrates analysis and calls these builders.
  * @see ARCHITECTURE.md                 — Data flow step 2.
@@ -25,54 +26,26 @@ class PRAutoBlogger_Analysis_Prompts {
 	 * @return string System prompt text.
 	 */
 	public static function build_system_prompt( string $niche, string $performance_context, int $target_count = 6 ): string {
-		$prompt = 'You are a content strategist analyzing social media discussions to find article ideas for a blog';
-		if ( '' !== $niche ) {
-			$prompt .= " in the {$niche} niche";
-		}
-		$prompt .= ".\n\n";
-
-		$prompt .= "IMPORTANT: You must identify exactly {$target_count} DISTINCT article ideas. ";
-		$prompt .= 'Each idea must cover a substantially different topic — no two ideas should overlap ';
-		$prompt .= "in their main subject. Aim for diversity across these categories:\n";
-		$prompt .= "1. QUESTIONS: Recurring questions people ask (\"How do I...\", \"What is...\", \"Is it safe to...\")\n";
-		$prompt .= "2. COMPLAINTS: Pain points, frustrations, or problems people report\n";
-		$prompt .= "3. COMPARISONS: Product/method comparisons people discuss (\"X vs Y\", \"Which is better\")\n";
-		$prompt .= "4. NEWS: Recent developments, rule changes, or trends people are discussing\n";
-		$prompt .= "5. GUIDES: How-to topics, best practices, or educational content people need\n\n";
-
-		$prompt .= "Spread your {$target_count} ideas across multiple categories. ";
-		$prompt .= 'Be specific — "peptide dosing for BPC-157" is better than "peptide information". ';
-		$prompt .= "Each idea should be narrow enough to be a single focused blog post.\n\n";
-
-		$prompt .= "For each idea, provide:\n";
-		$prompt .= "- type: 'question', 'complaint', 'comparison', 'news', or 'guide'\n";
-		$prompt .= "- topic: A clear, specific, narrow topic description\n";
-		$prompt .= "- summary: 1-2 sentence summary of why this topic matters\n";
-		$prompt .= "- frequency: How many of the provided posts relate to this topic\n";
-		$prompt .= "- relevance_score: 0.0 to 1.0 indicating how relevant and article-worthy this is\n";
-		$prompt .= "- suggested_title: A compelling, unique blog post title\n";
-		$prompt .= "- key_points: Array of 3-5 key points the article should cover\n";
-		$prompt .= "- target_keywords: Array of SEO keywords for this topic\n\n";
-
-		if ( '' !== $performance_context ) {
-			$prompt .= $performance_context . "\n\n";
-		}
+		// Blocks carry their own separators when non-empty so the rendered
+		// output is byte-identical to the historical concatenation.
+		$performance_block = '' !== $performance_context ? $performance_context . "\n\n" : '';
 
 		$recent_context = self::get_recent_articles_context();
-		if ( '' !== $recent_context ) {
-			$prompt .= $recent_context . "\n\n";
-		}
+		$recent_block   = '' !== $recent_context ? $recent_context . "\n\n" : '';
 
-		// Append user-defined analysis instructions if configured.
-		$instructions = trim( (string) get_option( 'prautoblogger_analysis_instructions', '' ) );
-		if ( '' !== $instructions ) {
-			$prompt .= "Additional instructions:\n" . $instructions . "\n\n";
-		}
+		$instructions       = trim( (string) get_option( 'prautoblogger_analysis_instructions', '' ) );
+		$instructions_block = '' !== $instructions ? "Additional instructions:\n" . $instructions . "\n\n" : '';
 
-		$prompt .= "Respond with valid JSON containing exactly {$target_count} patterns:\n";
-		$prompt .= '{"patterns": [{"type": "...", "topic": "...", "summary": "...", "frequency": N, "relevance_score": 0.X, "suggested_title": "...", "key_points": [...], "target_keywords": [...]}]}';
-
-		return $prompt;
+		return PRAutoBlogger_Prompt_Registry::render(
+			'analysis.system',
+			array(
+				'niche_clause'          => '' !== $niche ? " in the {$niche} niche" : '',
+				'target_count'          => (string) $target_count,
+				'performance_block'     => $performance_block,
+				'recent_articles_block' => $recent_block,
+				'instructions_block'    => $instructions_block,
+			)
+		);
 	}
 
 	/**
@@ -83,9 +56,13 @@ class PRAutoBlogger_Analysis_Prompts {
 	 * @return string User prompt text.
 	 */
 	public static function build_user_prompt( string $summary, int $target_count = 6 ): string {
-		return 'Here are the recent social media posts and comments to analyze. '
-			. "Find {$target_count} distinct, diverse article ideas from this data:\n\n"
-			. $summary;
+		return PRAutoBlogger_Prompt_Registry::render(
+			'analysis.user',
+			array(
+				'target_count' => (string) $target_count,
+				'summary'      => $summary,
+			)
+		);
 	}
 
 	/**

--- a/includes/core/class-article-worker.php
+++ b/includes/core/class-article-worker.php
@@ -9,8 +9,15 @@ declare(strict_types=1);
  * Extracted from Pipeline_Runner so each chained cron job has a focused,
  * single-responsibility worker. One worker = one article = one PHP process.
  *
+ * v0.18.0: per-article stage state (run_stages, item-scoped) makes resume
+ * idempotent — an already-published item is skipped outright, a done
+ * review is reused from its snapshot, and the writer reuses done LLM
+ * stages via Content_Generator::set_run_item(). Editorial verdicts and
+ * the sources that fed the article are persisted to the audit tables.
+ *
  * Triggered by: Pipeline_Runner (directly for article 1, via cron for 2..N).
- * Dependencies: Content_Generator, Chief_Editor, Publisher, Cost_Tracker.
+ * Dependencies: Content_Generator, Chief_Editor, Publisher, Cost_Tracker,
+ *               Run_Stage_State, Audit_Writer.
  *
  * Opik instrumentation: Initializes trace context at start, creates spans
  * for content generation and editorial review. Feature-flag gated (default off).
@@ -48,6 +55,27 @@ class PRAutoBlogger_Article_Worker {
 	 * @return array{generated: int, published: int, rejected: int, cost: float}
 	 */
 	public function generate( PRAutoBlogger_Article_Idea $idea ): array {
+		$run_id = (string) ( $this->cost_tracker->get_run_id() ?? '' );
+		$item   = PRAutoBlogger_Run_Stage_State::item_key_for_idea( $idea );
+
+		$result = array(
+			'generated' => 0,
+			'published' => 0,
+			'rejected'  => 0,
+			'cost'      => 0.0,
+		);
+
+		// Idempotent resume: this item already completed its publish stage
+		// in this run — re-dispatching it must not create a second post or
+		// charge a second cent.
+		if ( '' !== $run_id && PRAutoBlogger_Run_Stage_State::is_done( $run_id, 'publish', '', $item ) ) {
+			PRAutoBlogger_Logger::instance()->info(
+				sprintf( 'Skipping "%s" — already completed in run %s (idempotent resume).', $idea->get_topic(), $run_id ),
+				'pipeline'
+			);
+			return $result;
+		}
+
 		// Initialize Opik trace context for this article generation.
 		$opik = $this->should_trace_with_opik();
 		if ( $opik ) {
@@ -56,6 +84,7 @@ class PRAutoBlogger_Article_Worker {
 
 		$llm       = new PRAutoBlogger_OpenRouter_Provider();
 		$generator = new PRAutoBlogger_Content_Generator( $llm, $this->cost_tracker );
+		$generator->set_run_item( '' !== $run_id ? $run_id : null, $item );
 		$editor    = new PRAutoBlogger_Chief_Editor( $llm, $this->cost_tracker );
 		$publisher = new PRAutoBlogger_Publisher();
 
@@ -65,22 +94,16 @@ class PRAutoBlogger_Article_Worker {
 			true
 		);
 
-		$result = array(
-			'generated' => 0,
-			'published' => 0,
-			'rejected'  => 0,
-			'cost'      => 0.0,
-		);
-
 		try {
-			$this->broadcast_stage( __( 'Generating article draft via AI…', 'prautoblogger' ) );
+			PRAutoBlogger_Pipeline_Status::broadcast( __( 'Generating article draft via AI…', 'prautoblogger' ) );
 			$content             = $generator->generate( $idea );
 			$result['generated'] = 1;
 
-			$this->broadcast_stage( __( 'Running editorial pass…', 'prautoblogger' ) );
-			$review = $editor->review( $content, $idea );
+			PRAutoBlogger_Pipeline_Status::broadcast( __( 'Running editorial pass…', 'prautoblogger' ) );
+			$review = $this->review_with_state( $editor, $content, $idea, $run_id, $item );
 
-			$this->broadcast_stage( __( 'Saving and publishing…', 'prautoblogger' ) );
+			PRAutoBlogger_Pipeline_Status::broadcast( __( 'Saving and publishing…', 'prautoblogger' ) );
+			PRAutoBlogger_Run_Stage_State::start( $run_id, 'publish', '', $item );
 			$this->publish_or_draft(
 				$content,
 				$idea,
@@ -89,7 +112,13 @@ class PRAutoBlogger_Article_Worker {
 				$auto_publish,
 				$result
 			);
+			PRAutoBlogger_Run_Stage_State::done( $run_id, 'publish', '', $item );
+
+			PRAutoBlogger_Audit_Writer::record_idea_sources( $run_id, $idea );
 		} catch ( \Throwable $e ) {
+			if ( '' !== $run_id ) {
+				PRAutoBlogger_Run_Stage_State::fail_open_for_item( $run_id, $item );
+			}
 			PRAutoBlogger_Logger::instance()->error(
 				sprintf(
 					'Article generation %s for "%s": %s',
@@ -109,6 +138,63 @@ class PRAutoBlogger_Article_Worker {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Editorial review with stage state: a done review is reused from its
+	 * snapshot (never re-charged); a fresh review is checkpointed and its
+	 * verdict recorded to the run_decisions audit table.
+	 *
+	 * Side effects: run_stages upserts, one run_decisions insert, and —
+	 * when not resuming — one LLM call via Chief_Editor.
+	 *
+	 * @param PRAutoBlogger_Chief_Editor $editor  Editor agent.
+	 * @param string                     $content Generated HTML content.
+	 * @param PRAutoBlogger_Article_Idea $idea    The idea under review.
+	 * @param string                     $run_id  Run UUID ('' outside a run).
+	 * @param string                     $item    Stage item key for this idea.
+	 * @return PRAutoBlogger_Editorial_Review
+	 */
+	private function review_with_state(
+		PRAutoBlogger_Chief_Editor $editor,
+		string $content,
+		PRAutoBlogger_Article_Idea $idea,
+		string $run_id,
+		string $item
+	): PRAutoBlogger_Editorial_Review {
+		if ( '' !== $run_id ) {
+			$snapshot = PRAutoBlogger_Run_Stage_State::get_output( $run_id, 'review', '', $item );
+			if ( null !== $snapshot ) {
+				$data = json_decode( $snapshot, true );
+				if ( is_array( $data ) && isset( $data['verdict'] ) ) {
+					PRAutoBlogger_Logger::instance()->info(
+						sprintf( 'Reusing completed review for "%s" (idempotent resume).', $idea->get_topic() ),
+						'pipeline'
+					);
+					return new PRAutoBlogger_Editorial_Review( $data );
+				}
+			}
+			PRAutoBlogger_Run_Stage_State::start( $run_id, 'review', '', $item );
+		}
+
+		$review = $editor->review( $content, $idea );
+
+		if ( '' !== $run_id ) {
+			$snapshot = (string) wp_json_encode(
+				array(
+					'verdict'         => $review->get_verdict(),
+					'notes'           => $review->get_notes(),
+					'revised_content' => $review->get_revised_content(),
+					'quality_score'   => $review->get_quality_score(),
+					'seo_score'       => $review->get_seo_score(),
+					'issues'          => $review->get_issues(),
+				)
+			);
+			PRAutoBlogger_Run_Stage_State::done( $run_id, 'review', '', $item, $snapshot );
+			PRAutoBlogger_Audit_Writer::record_decision( $run_id, 'review', $review->get_verdict(), $review->get_notes() );
+		}
+
+		return $review;
 	}
 
 	/**
@@ -150,21 +236,6 @@ class PRAutoBlogger_Article_Worker {
 				'Article rejected by editor: ' . $idea->get_topic(),
 				'pipeline'
 			);
-		}
-	}
-
-	/**
-	 * Update the generation status transient with the current stage.
-	 *
-	 * @param string $stage Human-readable stage description.
-	 */
-	private function broadcast_stage( string $stage ): void {
-		$transient_key = 'prautoblogger_generation_status';
-		$current       = get_transient( $transient_key );
-		if ( is_array( $current ) && 'running' === ( $current['status'] ?? '' ) ) {
-			$current['stage']        = $stage;
-			$current['last_updated'] = time();
-			set_transient( $transient_key, $current, 600 );
 		}
 	}
 

--- a/includes/core/class-audit-writer.php
+++ b/includes/core/class-audit-writer.php
@@ -1,0 +1,132 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * phpcs:ignore WordPress.Files.FileName.InvalidClassFileName -- class naming convention differs from WordPress standard
+ *
+ * Writes run-scoped audit rows: sources considered + stage decisions.
+ *
+ * What: Thin, self-healing insert layer over the v0.18.0 audit child
+ *       tables. `record_decision()` persists a stage verdict (Phase 1:
+ *       the chief editor's review verdict; Phase 2 adds curate/editorial/
+ *       seo decisions and citation_score). `record_idea_sources()`
+ *       consolidates which collected sources fed a generated article —
+ *       the run_sources replacement for the historical source_ids_json /
+ *       `_prautoblogger_research_sources` scatter — for NEW runs only (no
+ *       backfill). Every method no-ops when the tables are missing.
+ * Who triggers it: Article_Worker (decision after review, sources after
+ *       publish), Phase-2 agents.
+ * Dependencies: WordPress $wpdb, Run_State (availability probe pattern).
+ *
+ * @see core/class-article-worker.php — Phase-1 call sites.
+ * @see ARCHITECTURE.md #21           — Audit substrate design.
+ */
+class PRAutoBlogger_Audit_Writer {
+
+	/** @var bool|null Per-request "audit tables exist" probe result. */
+	private static ?bool $tables_ok = null;
+
+	/**
+	 * Whether the audit child tables exist. Cached per request; never throws.
+	 *
+	 * @return bool
+	 */
+	public static function is_available(): bool {
+		if ( null !== self::$tables_ok ) {
+			return self::$tables_ok;
+		}
+		global $wpdb;
+		if ( null === $wpdb ) {
+			return false; // Not cached: $wpdb may appear later in boot.
+		}
+		$table = $wpdb->prefix . 'prautoblogger_run_decisions';
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$found           = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+		self::$tables_ok = ( $found === $table );
+		return self::$tables_ok;
+	}
+
+	/**
+	 * Persist a stage decision for a run.
+	 *
+	 * @param string     $run_id         Run UUID.
+	 * @param string     $stage          Deciding stage (see Stage_Display_Map).
+	 * @param string     $verdict        e.g. 'approved', 'revised', 'rejected'.
+	 * @param string     $rationale      Why (editor notes, governor message, …).
+	 * @param float|null $citation_score Phase-2 citation score (null in Phase 1).
+	 * @return void
+	 */
+	public static function record_decision( string $run_id, string $stage, string $verdict, string $rationale = '', ?float $citation_score = null ): void {
+		if ( '' === $run_id || ! self::is_available() ) {
+			return;
+		}
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$wpdb->insert(
+			$wpdb->prefix . 'prautoblogger_run_decisions',
+			array(
+				'run_id'         => $run_id,
+				'stage'          => $stage,
+				'verdict'        => $verdict,
+				'rationale'      => $rationale,
+				'citation_score' => $citation_score,
+				'created_at'     => current_time( 'mysql' ),
+			)
+		);
+	}
+
+	/**
+	 * Record the collected sources that fed a generated article (kept = 1;
+	 * Phase-2 curation adds discard rows with reasons + quality scores).
+	 *
+	 * Resolves the idea's source_data ids to permalinks in one query.
+	 *
+	 * @param string                     $run_id Run UUID.
+	 * @param PRAutoBlogger_Article_Idea $idea   The generated idea.
+	 * @return void
+	 */
+	public static function record_idea_sources( string $run_id, PRAutoBlogger_Article_Idea $idea ): void {
+		if ( '' === $run_id || ! self::is_available() ) {
+			return;
+		}
+		$source_ids = array_filter( array_map( 'intval', $idea->get_source_ids() ) );
+		if ( empty( $source_ids ) ) {
+			return;
+		}
+
+		global $wpdb;
+		$source_table = $wpdb->prefix . 'prautoblogger_source_data';
+		$placeholders = implode( ',', array_fill( 0, count( $source_ids ), '%d' ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$rows = $wpdb->get_results(
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $placeholders is a fixed %d list.
+			$wpdb->prepare( "SELECT id, source_type, permalink FROM {$source_table} WHERE id IN ({$placeholders})", $source_ids ),
+			ARRAY_A
+		);
+		if ( ! is_array( $rows ) ) {
+			return;
+		}
+
+		foreach ( $rows as $row ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+			$wpdb->insert(
+				$wpdb->prefix . 'prautoblogger_run_sources',
+				array(
+					'run_id'        => $run_id,
+					'agent_role'    => 'analyst',
+					'source_url'    => (string) ( $row['permalink'] ?? '' ),
+					'doi'           => null,
+					'kept'          => 1,
+					'reason'        => sprintf( 'Cited by analyzer for "%s" (%s #%d)', $idea->get_topic(), (string) $row['source_type'], (int) $row['id'] ),
+					'quality_score' => null,
+					'created_at'    => current_time( 'mysql' ),
+				)
+			);
+		}
+	}
+
+	/** Reset per-request caches (tests). */
+	public static function flush_cache(): void {
+		self::$tables_ok = null;
+	}
+}

--- a/includes/core/class-chief-editor.php
+++ b/includes/core/class-chief-editor.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
  * Opik instrumentation: spans per review LLM call.
  *
  * Triggered by: PRAutoBlogger_Article_Worker.
- * Dependencies: LLM_Provider_Interface, Cost_Tracker.
+ * Dependencies: LLM_Provider_Interface, Cost_Tracker, Prompt_Registry.
  */
 class PRAutoBlogger_Chief_Editor {
 
@@ -92,54 +92,47 @@ class PRAutoBlogger_Chief_Editor {
 
 	/**
 	 * Build system prompt for editorial review.
+	 *
+	 * v0.18.0: renders from the versioned registry ('editor.system') with a
+	 * byte-identical in-code fallback; the admin's extra editor
+	 * instructions stay a setting and are injected as a token value.
+	 *
+	 * @param string $niche Niche description from settings.
+	 * @return string System prompt text.
 	 */
 	private function build_system_prompt( string $niche ): string {
-		$prompt = 'You are a senior blog editor';
-		if ( '' !== $niche ) {
-			$prompt .= " specializing in {$niche} content";
-		}
-		$prompt .= ". Review article drafts before publication.\n\n";
+		$instructions       = trim( (string) get_option( 'prautoblogger_editor_instructions', '' ) );
+		$instructions_block = '' !== $instructions ? "\nAdditional instructions:\n" . $instructions . "\n" : '';
 
-		$prompt .= "Evaluate on: QUALITY, ACCURACY, SEO, COMPLETENESS, READABILITY.\n";
-		$prompt .= "Respond with JSON: {\n";
-		$prompt .= '  "verdict": "approved" | "revised" | "rejected",' . "\n";
-		$prompt .= '  "quality_score": 0.0-1.0,' . "\n";
-		$prompt .= '  "seo_score": 0.0-1.0,' . "\n";
-		$prompt .= '  "issues": ["issue1", "issue2"],' . "\n";
-		$prompt .= '  "notes": "Editorial notes",' . "\n";
-		$prompt .= '  "revised_content": "Full revised HTML if revised, null otherwise"' . "\n";
-		$prompt .= "}\n\n";
-
-		$prompt .= "Rules:\n";
-		$prompt .= "- APPROVE if quality_score >= 0.7 and seo_score >= 0.6\n";
-		$prompt .= "- REVISE if fixable issues exist — provide full revised HTML\n";
-		$prompt .= "- REJECT if fundamentally flawed\n";
-		$prompt .= "- Preserve formatting, links, lists when revising\n";
-
-		$instructions = trim( (string) get_option( 'prautoblogger_editor_instructions', '' ) );
-		if ( '' !== $instructions ) {
-			$prompt .= "\nAdditional instructions:\n" . $instructions . "\n";
-		}
-
-		return $prompt;
+		return PRAutoBlogger_Prompt_Registry::render(
+			'editor.system',
+			array(
+				'niche_clause'       => '' !== $niche ? " specializing in {$niche} content" : '',
+				'instructions_block' => $instructions_block,
+			)
+		);
 	}
 
 	/**
 	 * Build user prompt for editorial review.
+	 *
+	 * v0.18.0: renders from the versioned registry ('editor.review').
+	 *
+	 * @param string                     $content The generated HTML content.
+	 * @param PRAutoBlogger_Article_Idea $idea    The original article idea.
+	 * @return string User prompt text.
 	 */
 	private function build_review_prompt( string $content, PRAutoBlogger_Article_Idea $idea ): string {
-		return sprintf(
-			"Review this article draft:\n\n" .
-			"BRIEF: Title: %s | Topic: %s | Type: %s\n" .
-			"KEY POINTS: %s\n" .
-			"TARGET KEYWORDS: %s\n\n" .
-			"CONTENT:\n%s",
-			$idea->get_suggested_title(),
-			$idea->get_topic(),
-			$idea->get_article_type(),
-			implode( ', ', $idea->get_key_points() ),
-			implode( ', ', $idea->get_target_keywords() ),
-			$content
+		return PRAutoBlogger_Prompt_Registry::render(
+			'editor.review',
+			array(
+				'title'        => $idea->get_suggested_title(),
+				'topic'        => $idea->get_topic(),
+				'article_type' => $idea->get_article_type(),
+				'key_points'   => implode( ', ', $idea->get_key_points() ),
+				'keywords'     => implode( ', ', $idea->get_target_keywords() ),
+				'content'      => $content,
+			)
 		);
 	}
 

--- a/includes/core/class-content-generator.php
+++ b/includes/core/class-content-generator.php
@@ -6,6 +6,10 @@ declare(strict_types=1);
  *
  * Supports: single_pass (one LLM call) or multi_step (outline → draft → polish).
  * Opik instrumentation: spans per LLM call when feature-flag enabled.
+ * v0.18.0: prompt copy renders from the versioned prompt registry (with
+ * byte-identical in-code fallback); every log row carries the run-pinned
+ * prompt_version. The four stage methods share one execute_stage() helper —
+ * span lifecycle, LLM dispatch, and cost logging are identical across stages.
  *
  * Triggered by: PRAutoBlogger_Article_Worker.
  * Dependencies: LLM_Provider_Interface, Cost_Tracker, Content_Prompts.
@@ -26,7 +30,8 @@ class PRAutoBlogger_Content_Generator {
 	/**
 	 * Generate a blog post from an article idea.
 	 *
-	 * @param PRAutoBlogger_Article_Idea $idea The scored idea to generate content for.
+	 * @param PRAutoBlogger_Article_Idea $idea      The scored idea to generate content for.
+	 * @param bool                       $eval_mode True to suppress publish/image side effects.
 	 * @return string Generated HTML content.
 	 */
 	public function generate( PRAutoBlogger_Article_Idea $idea, bool $eval_mode = false ): string {
@@ -52,101 +57,47 @@ class PRAutoBlogger_Content_Generator {
 	}
 
 	/**
-	 * Single-pass: one LLM call produces complete article.
+	 * Single-pass: one LLM call produces complete article (Economy tier).
+	 *
+	 * The log row's stage stays 'draft' (historical contract: a draft row
+	 * without an outline row marks a single-pass run) but the prompt key
+	 * is passed explicitly — the stage map would resolve 'draft' to
+	 * 'content.draft'.
+	 *
+	 * @param PRAutoBlogger_Content_Request $request Generation request.
+	 * @return string Generated HTML content.
 	 */
 	private function generate_single_pass( PRAutoBlogger_Content_Request $request ): string {
 		$model = get_option( 'prautoblogger_writing_model', PRAUTOBLOGGER_DEFAULT_WRITING_MODEL );
-		$ctx = PRAutoBlogger_Opik_Trace_Context::current();
 
-		$span_id = $ctx->start_span(
-			array(
-				'name'     => 'single_pass_generation',
-				'type'     => 'llm',
-				'model'    => $model,
-				'provider' => 'openrouter',
-			)
-		);
-
-		$response = $this->llm->send_chat_completion(
-			array(
-				array(
-					'role'    => 'system',
-					'content' => PRAutoBlogger_Content_Prompts::build_system( $request ),
-				),
-				array(
-					'role'    => 'user',
-					'content' => PRAutoBlogger_Content_Prompts::build_single_pass( $request ),
-				),
-			),
+		return $this->execute_stage(
+			'draft',
+			'single_pass_generation',
+			PRAutoBlogger_Content_Prompts::build_single_pass( $request ),
+			$request,
 			$model,
 			array(
 				'temperature' => 0.7,
 				'max_tokens'  => 4000,
-			)
+			),
+			'content.single_pass'
 		);
-
-		$ctx->end_span(
-			$span_id,
-			array(
-				'usage' => array(
-					'prompt_tokens'     => $response['prompt_tokens'],
-					'completion_tokens' => $response['completion_tokens'],
-					'total_tokens'      => $response['prompt_tokens'] + $response['completion_tokens'],
-				),
-			)
-		);
-
-		$this->cost_tracker->log_api_call(
-			null,
-			'draft',
-			$this->llm->get_provider_name(),
-			$response['model'],
-			$response['prompt_tokens'],
-			$response['completion_tokens']
-		);
-
-		return $response['content'];
 	}
 
 	/**
 	 * Multi-step: outline → draft → polish.
+	 *
+	 * @param PRAutoBlogger_Content_Request $request Generation request.
+	 * @return string Generated HTML content.
 	 */
 	private function generate_multi_step( PRAutoBlogger_Content_Request $request ): string {
 		$model = get_option( 'prautoblogger_writing_model', PRAUTOBLOGGER_DEFAULT_WRITING_MODEL );
 
-		$outline  = $this->stage_outline( $request, $model );
-		$draft    = $this->stage_draft( $request, $outline, $model );
-		$polished = $this->stage_polish( $request, $draft, $model );
-
-		return $polished;
-	}
-
-	/**
-	 * Stage 1: Generate article outline.
-	 */
-	private function stage_outline( PRAutoBlogger_Content_Request $request, string $model ): string {
-		$ctx = PRAutoBlogger_Opik_Trace_Context::current();
-
-		$span_id = $ctx->start_span(
-			array(
-				'name'     => 'outline_generation',
-				'type'     => 'llm',
-				'model'    => $model,
-				'provider' => 'openrouter',
-			)
-		);
-
-		$response = $this->llm->send_chat_completion(
-			array(
-				array(
-					'role'    => 'system',
-					'content' => PRAutoBlogger_Content_Prompts::build_system( $request ),
-				),
-				array(
-					'role'    => 'user',
-					'content' => PRAutoBlogger_Content_Prompts::build_outline( $request ),
-				),
-			),
+		$outline = $this->execute_stage(
+			'outline',
+			'outline_generation',
+			PRAutoBlogger_Content_Prompts::build_outline( $request ),
+			$request,
 			$model,
 			array(
 				'temperature' => 0.5,
@@ -154,55 +105,11 @@ class PRAutoBlogger_Content_Generator {
 			)
 		);
 
-		$ctx->end_span(
-			$span_id,
-			array(
-				'usage' => array(
-					'prompt_tokens'     => $response['prompt_tokens'],
-					'completion_tokens' => $response['completion_tokens'],
-					'total_tokens'      => $response['prompt_tokens'] + $response['completion_tokens'],
-				),
-			)
-		);
-
-		$this->cost_tracker->log_api_call(
-			null,
-			'outline',
-			$this->llm->get_provider_name(),
-			$response['model'],
-			$response['prompt_tokens'],
-			$response['completion_tokens']
-		);
-
-		return $response['content'];
-	}
-
-	/**
-	 * Stage 2: Write full draft from outline.
-	 */
-	private function stage_draft( PRAutoBlogger_Content_Request $request, string $outline, string $model ): string {
-		$ctx = PRAutoBlogger_Opik_Trace_Context::current();
-
-		$span_id = $ctx->start_span(
-			array(
-				'name'     => 'draft_generation',
-				'type'     => 'llm',
-				'model'    => $model,
-				'provider' => 'openrouter',
-			)
-		);
-
-		$response = $this->llm->send_chat_completion(
-			array(
-				array(
-					'role'    => 'system',
-					'content' => PRAutoBlogger_Content_Prompts::build_system( $request ),
-				),
-				array(
-					'role'    => 'user',
-					'content' => PRAutoBlogger_Content_Prompts::build_draft( $request, $outline ),
-				),
-			),
+		$draft = $this->execute_stage(
+			'draft',
+			'draft_generation',
+			PRAutoBlogger_Content_Prompts::build_draft( $request, $outline ),
+			$request,
 			$model,
 			array(
 				'temperature' => 0.7,
@@ -210,38 +117,53 @@ class PRAutoBlogger_Content_Generator {
 			)
 		);
 
-		$ctx->end_span(
-			$span_id,
+		return $this->execute_stage(
+			'polish',
+			'polish_generation',
+			PRAutoBlogger_Content_Prompts::build_polish( $draft ),
+			$request,
+			$model,
 			array(
-				'usage' => array(
-					'prompt_tokens'     => $response['prompt_tokens'],
-					'completion_tokens' => $response['completion_tokens'],
-					'total_tokens'      => $response['prompt_tokens'] + $response['completion_tokens'],
-				),
+				'temperature' => 0.4,
+				'max_tokens'  => 4000,
 			)
 		);
-
-		$this->cost_tracker->log_api_call(
-			null,
-			'draft',
-			$this->llm->get_provider_name(),
-			$response['model'],
-			$response['prompt_tokens'],
-			$response['completion_tokens']
-		);
-
-		return $response['content'];
 	}
 
 	/**
-	 * Stage 3: Polish and refine draft.
+	 * Run one writing stage: Opik span → LLM call → span close → cost log.
+	 *
+	 * Consolidates the per-stage boilerplate that was previously duplicated
+	 * across the four stage methods (v0.18.0). The system prompt is rebuilt
+	 * per stage exactly as before.
+	 *
+	 * Side effects: one OpenRouter API call, one Opik span (when tracing),
+	 * one generation_log row.
+	 *
+	 * @param string                        $stage       Log stage value ('outline'|'draft'|'polish').
+	 * @param string                        $span_name   Opik span name.
+	 * @param string                        $user_prompt Rendered user prompt for the stage.
+	 * @param PRAutoBlogger_Content_Request $request     Generation request (system prompt input).
+	 * @param string                        $model       Model identifier.
+	 * @param array<string, mixed>          $options     LLM options (temperature, max_tokens).
+	 * @param string|null                   $prompt_key  Explicit registry key for prompt_version
+	 *                                                   stamping (null = derive from stage).
+	 * @return string Stage output content.
 	 */
-	private function stage_polish( PRAutoBlogger_Content_Request $request, string $draft, string $model ): string {
+	private function execute_stage(
+		string $stage,
+		string $span_name,
+		string $user_prompt,
+		PRAutoBlogger_Content_Request $request,
+		string $model,
+		array $options,
+		?string $prompt_key = null
+	): string {
 		$ctx = PRAutoBlogger_Opik_Trace_Context::current();
 
 		$span_id = $ctx->start_span(
 			array(
-				'name'     => 'polish_generation',
+				'name'     => $span_name,
 				'type'     => 'llm',
 				'model'    => $model,
 				'provider' => 'openrouter',
@@ -256,14 +178,11 @@ class PRAutoBlogger_Content_Generator {
 				),
 				array(
 					'role'    => 'user',
-					'content' => PRAutoBlogger_Content_Prompts::build_polish( $draft ),
+					'content' => $user_prompt,
 				),
 			),
 			$model,
-			array(
-				'temperature' => 0.4,
-				'max_tokens'  => 4000,
-			)
+			$options
 		);
 
 		$ctx->end_span(
@@ -279,11 +198,15 @@ class PRAutoBlogger_Content_Generator {
 
 		$this->cost_tracker->log_api_call(
 			null,
-			'polish',
+			$stage,
 			$this->llm->get_provider_name(),
 			$response['model'],
 			$response['prompt_tokens'],
-			$response['completion_tokens']
+			$response['completion_tokens'],
+			'success',
+			'',
+			null,
+			$prompt_key
 		);
 
 		return $response['content'];

--- a/includes/core/class-content-generator.php
+++ b/includes/core/class-content-generator.php
@@ -19,12 +19,37 @@ class PRAutoBlogger_Content_Generator {
 	private PRAutoBlogger_LLM_Provider_Interface $llm;
 	private PRAutoBlogger_Cost_Tracker $cost_tracker;
 
+	/** @var string|null Run UUID for stage-state checkpointing (null = off). */
+	private ?string $run_id = null;
+
+	/** @var string|null Stage item key scoping this article within the run. */
+	private ?string $item_key = null;
+
 	public function __construct(
 		PRAutoBlogger_LLM_Provider_Interface $llm,
 		PRAutoBlogger_Cost_Tracker $cost_tracker
 	) {
 		$this->llm          = $llm;
 		$this->cost_tracker = $cost_tracker;
+	}
+
+	/**
+	 * Enable per-stage state checkpointing for one article item (v0.18.0).
+	 *
+	 * When set, every LLM stage (outline/draft/polish or the single-pass
+	 * draft) records pending->running->done state and snapshots its output;
+	 * a re-entered done stage returns the snapshot WITHOUT a new LLM call
+	 * (never re-charged). When unset (default), behavior is exactly
+	 * pre-v0.18.0 — used by callers outside a run (e.g. eval mode).
+	 *
+	 * @param string|null $run_id   Run UUID, or null to disable.
+	 * @param string|null $item_key Item key from Run_Stage_State::item_key_for_idea().
+	 * @return $this
+	 */
+	public function set_run_item( ?string $run_id, ?string $item_key ): self {
+		$this->run_id   = $run_id;
+		$this->item_key = $item_key;
+		return $this;
 	}
 
 	/**
@@ -159,6 +184,19 @@ class PRAutoBlogger_Content_Generator {
 		array $options,
 		?string $prompt_key = null
 	): string {
+		// Idempotent resume: a done stage returns its snapshot, no LLM call.
+		if ( null !== $this->run_id && null !== $this->item_key ) {
+			$cached = PRAutoBlogger_Run_Stage_State::get_output( $this->run_id, $stage, '', $this->item_key );
+			if ( null !== $cached ) {
+				PRAutoBlogger_Logger::instance()->info(
+					sprintf( 'Reusing completed %s stage output (idempotent resume).', $stage ),
+					'pipeline'
+				);
+				return $cached;
+			}
+			PRAutoBlogger_Run_Stage_State::start( $this->run_id, $stage, '', $this->item_key );
+		}
+
 		$ctx = PRAutoBlogger_Opik_Trace_Context::current();
 
 		$span_id = $ctx->start_span(
@@ -208,6 +246,17 @@ class PRAutoBlogger_Content_Generator {
 			null,
 			$prompt_key
 		);
+
+		if ( null !== $this->run_id && null !== $this->item_key ) {
+			PRAutoBlogger_Run_Stage_State::done(
+				$this->run_id,
+				$stage,
+				'',
+				$this->item_key,
+				(string) $response['content'],
+				$this->llm->estimate_cost( $response['model'], (int) $response['prompt_tokens'], (int) $response['completion_tokens'] )
+			);
+		}
 
 		return $response['content'];
 	}

--- a/includes/core/class-content-prompts.php
+++ b/includes/core/class-content-prompts.php
@@ -11,7 +11,8 @@ declare(strict_types=1);
  * independently of the generation orchestration.
  *
  * Triggered by: PRAutoBlogger_Content_Generator (called for every stage).
- * Dependencies: WordPress query functions (get_posts, get_the_title, get_permalink).
+ * Dependencies: PRAutoBlogger_Prompt_Registry (versioned prompt bodies),
+ *               WordPress query functions (get_posts, get_the_title, get_permalink).
  *
  * @see core/class-content-generator.php — Consumer of these prompts.
  * @see models/class-content-request.php — Data bag passed to every builder.
@@ -24,18 +25,22 @@ class PRAutoBlogger_Content_Prompts {
 	 * Includes niche, tone, mandatory style guide, internal link reference,
 	 * peptide database links, and the "never fabricate URLs" rule.
 	 *
+	 * v0.18.0: the prompt copy renders from the versioned registry
+	 * ('content.system', falls back to the identical in-code default);
+	 * the style guide and linking rules are data injection and stay here.
+	 *
 	 * @param PRAutoBlogger_Content_Request $request Content request with settings.
 	 * @return string Complete system prompt.
 	 */
 	public static function build_system( PRAutoBlogger_Content_Request $request ): string {
 		$niche  = $request->get_niche_description();
-		$prompt = 'You are an expert blog writer';
-		if ( '' !== $niche ) {
-			$prompt .= " specializing in {$niche}";
-		}
-		$prompt .= '. Write well-researched, engaging, SEO-friendly content. ';
-		$prompt .= "Use a {$request->get_tone()} tone. ";
-		$prompt .= 'Output HTML content only — no markdown, no code fences, no commentary.';
+		$prompt = PRAutoBlogger_Prompt_Registry::render(
+			'content.system',
+			array(
+				'niche_clause' => '' !== $niche ? " specializing in {$niche}" : '',
+				'tone'         => $request->get_tone(),
+			)
+		);
 
 		// Append user-defined writing instructions as a mandatory style guide.
 		$instructions = trim( $request->get_writing_instructions() );
@@ -60,24 +65,17 @@ class PRAutoBlogger_Content_Prompts {
 	public static function build_single_pass( PRAutoBlogger_Content_Request $request ): string {
 		$idea = $request->get_idea();
 
-		return sprintf(
-			"Write a complete blog post in HTML format.\n\n" .
-			"Title: %s\nTopic: %s\nType: %s\n\nKey points:\n- %s\n\n" .
-			"Keywords: %s\n\n" .
-			"Requirements:\n" .
-			"- %d-%d words\n" .
-			"- Proper HTML (h2, h3, p, ul/li)\n" .
-			"- Engaging intro, strong conclusion with CTA\n" .
-			"- Do NOT include the title or <html>/<body> tags\n" .
-			"- Output HTML only, no markdown or commentary\n" .
-			'- Follow EVERY formatting and structural requirement from your system prompt style guide',
-			$idea->get_suggested_title(),
-			$idea->get_topic(),
-			$idea->get_article_type(),
-			implode( "\n- ", $idea->get_key_points() ),
-			implode( ', ', $idea->get_target_keywords() ),
-			$request->get_min_word_count(),
-			$request->get_max_word_count()
+		return PRAutoBlogger_Prompt_Registry::render(
+			'content.single_pass',
+			array(
+				'title'        => $idea->get_suggested_title(),
+				'topic'        => $idea->get_topic(),
+				'article_type' => $idea->get_article_type(),
+				'key_points'   => implode( "\n- ", $idea->get_key_points() ),
+				'keywords'     => implode( ', ', $idea->get_target_keywords() ),
+				'min_words'    => (string) $request->get_min_word_count(),
+				'max_words'    => (string) $request->get_max_word_count(),
+			)
 		);
 	}
 
@@ -90,21 +88,17 @@ class PRAutoBlogger_Content_Prompts {
 	public static function build_outline( PRAutoBlogger_Content_Request $request ): string {
 		$idea = $request->get_idea();
 
-		return sprintf(
-			"Create a detailed outline for a blog post titled: \"%s\"\n\n" .
-			"Topic: %s\nArticle type: %s\n\nKey points to cover:\n%s\n\n" .
-			"Target keywords: %s\n\n" .
-			'The outline should have 4-6 main sections with bullet points under each. ' .
-			'Include an introduction hook and a conclusion with a call to action. ' .
-			"Word count target: %d-%d words.\n\n" .
-			'Plan the structure to satisfy EVERY requirement in your system prompt style guide.',
-			$idea->get_suggested_title(),
-			$idea->get_topic(),
-			$idea->get_article_type(),
-			implode( "\n- ", $idea->get_key_points() ),
-			implode( ', ', $idea->get_target_keywords() ),
-			$request->get_min_word_count(),
-			$request->get_max_word_count()
+		return PRAutoBlogger_Prompt_Registry::render(
+			'content.outline',
+			array(
+				'title'        => $idea->get_suggested_title(),
+				'topic'        => $idea->get_topic(),
+				'article_type' => $idea->get_article_type(),
+				'key_points'   => implode( "\n- ", $idea->get_key_points() ),
+				'keywords'     => implode( ', ', $idea->get_target_keywords() ),
+				'min_words'    => (string) $request->get_min_word_count(),
+				'max_words'    => (string) $request->get_max_word_count(),
+			)
 		);
 	}
 
@@ -116,23 +110,15 @@ class PRAutoBlogger_Content_Prompts {
 	 * @return string Draft prompt.
 	 */
 	public static function build_draft( PRAutoBlogger_Content_Request $request, string $outline ): string {
-		return sprintf(
-			"Using this outline, write the full blog post in HTML format.\n\n" .
-			"OUTLINE:\n%s\n\n" .
-			"Requirements:\n" .
-			"- Write in a %s tone\n" .
-			"- Target %d-%d words\n" .
-			"- Use proper HTML headings (h2, h3), paragraphs, and lists\n" .
-			"- Include an engaging introduction and strong conclusion\n" .
-			"- Naturally incorporate these keywords: %s\n" .
-			"- Do NOT include the title in the HTML (it will be set separately)\n" .
-			"- Do NOT wrap in <html>, <head>, or <body> tags — just the article content\n" .
-			'- Follow EVERY formatting and structural requirement from your system prompt style guide',
-			$outline,
-			$request->get_tone(),
-			$request->get_min_word_count(),
-			$request->get_max_word_count(),
-			implode( ', ', $request->get_idea()->get_target_keywords() )
+		return PRAutoBlogger_Prompt_Registry::render(
+			'content.draft',
+			array(
+				'outline'   => $outline,
+				'tone'      => $request->get_tone(),
+				'min_words' => (string) $request->get_min_word_count(),
+				'max_words' => (string) $request->get_max_word_count(),
+				'keywords'  => implode( ', ', $request->get_idea()->get_target_keywords() ),
+			)
 		);
 	}
 
@@ -143,18 +129,10 @@ class PRAutoBlogger_Content_Prompts {
 	 * @return string Polish prompt.
 	 */
 	public static function build_polish( string $draft ): string {
-		return "Review and polish this blog post draft. Improve:\n" .
-			"1. Flow and readability\n" .
-			"2. SEO optimization (headings, keyword placement)\n" .
-			"3. Engagement (hooks, transitions, call-to-action)\n" .
-			"4. Accuracy and clarity\n" .
-			"5. Remove any filler or redundant sentences\n\n" .
-			'IMPORTANT: Preserve all bullet points, numbered lists, hyperlinks, and ' .
-			'structural elements from the draft. Do NOT flatten lists into prose or ' .
-			'remove links. Ensure every requirement from your system prompt style ' .
-			"guide is satisfied in the final output.\n\n" .
-			"Return the polished HTML content only. Do not add commentary.\n\n" .
-			"DRAFT:\n" . $draft;
+		return PRAutoBlogger_Prompt_Registry::render(
+			'content.polish',
+			array( 'draft' => $draft )
+		);
 	}
 
 	/**

--- a/includes/core/class-cost-ceiling-exception.php
+++ b/includes/core/class-cost-ceiling-exception.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * phpcs:ignore WordPress.Files.FileName.InvalidClassFileName -- class naming convention differs from WordPress standard
+ *
+ * Thrown when a reserve-before-call would push a run past its cost ceiling.
+ *
+ * What: Dedicated exception type so call paths can distinguish "this run
+ *       was halted by the per-run cost governor" from generic API
+ *       failures. By the time it is thrown the governor has already
+ *       marked the run `halted`, recorded the overage on the runs row,
+ *       and logged — catchers must NOT dispatch the call they were about
+ *       to make, and chained jobs abort via the run-status check in
+ *       Pipeline_Runner::process_next_queued_article().
+ * Who triggers it: PRAutoBlogger_Cost_Governor on a failed reservation.
+ * Dependencies: none (extends RuntimeException).
+ *
+ * @see core/class-cost-governor.php      — Sole thrower.
+ * @see core/class-pipeline-runner.php    — Aborts queued articles of halted runs.
+ */
+class PRAutoBlogger_Cost_Ceiling_Exception extends \RuntimeException {
+}

--- a/includes/core/class-cost-governor.php
+++ b/includes/core/class-cost-governor.php
@@ -1,0 +1,239 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * phpcs:ignore WordPress.Files.FileName.InvalidClassFileName -- class naming convention differs from WordPress standard
+ *
+ * Per-run cost governor — reserve-before-call against the run ledger.
+ *
+ * What: Net-new enforcement (the monthly Cost_Tracker cap only bounds the
+ *       month; `get_current_run_cost()` was an unguarded accumulator).
+ *       Before any governed call dispatches, its worst-case cost estimate
+ *       is atomically added to the run's `reserved_usd` via a single
+ *       conditional UPDATE — the same atomic-conditional-write discipline
+ *       as PRAutoBlogger_Generation_Lock (#10) — so concurrent writers
+ *       (curl_multi fan-outs, chained jobs) cannot slip past the ceiling
+ *       between check and call. Batches reserve their SUMMED estimate
+ *       before dispatch. After each response the reservation settles to
+ *       the actual cost, so a cheap call never holds its worst case.
+ *       Breach: the run is marked `halted` (sticky), the overage is
+ *       recorded on the runs row, the Review Queue surfaces it, and a
+ *       Cost_Ceiling_Exception aborts the un-dispatched call. Standalone
+ *       calls outside any run (no run context) are not run-governed —
+ *       exactly the historical behavior; the monthly cap and the
+ *       Cloudflare AI Gateway path are untouched everywhere.
+ * Who triggers it: PRAutoBlogger_OpenRouter_Provider::send_chat_completion
+ *       (every text-LLM call path), PRAutoBlogger_Image_Pipeline (image
+ *       curl_multi batch).
+ * Dependencies: Run_Context (which run is this process in),
+ *       Run_State (ledger row + halt), OpenRouter_Pricing (#18 chain),
+ *       WordPress $wpdb, Logger.
+ *
+ * @see class-generation-lock.php            — The atomic-write pattern this mirrors.
+ * @see core/class-run-state.php             — The ledger row reserved against.
+ * @see providers/class-open-router-provider.php — Text-call integration point.
+ * @see core/class-image-pipeline.php        — Batch reservation integration point.
+ * @see ARCHITECTURE.md #21                  — Design rationale.
+ */
+class PRAutoBlogger_Cost_Governor {
+
+	/**
+	 * Rough chars-per-token divisor for prompt-size estimation. An internal
+	 * estimator detail (NOT a behavior setting — the enforced ceiling is
+	 * the prautoblogger_per_run_cost_ceiling_usd SETTING).
+	 */
+	private const CHARS_PER_TOKEN = 4;
+
+	/**
+	 * Worst-case completion tokens assumed when a caller sets no
+	 * max_tokens. Every current call site sets one; this is belt-and-braces.
+	 */
+	private const DEFAULT_MAX_COMPLETION_TOKENS = 4096;
+
+	/**
+	 * Reserve the worst-case cost of one chat-completion call for the
+	 * process's current run. Call before dispatch.
+	 *
+	 * Returns null (call proceeds ungoverned, exactly as pre-v0.18.0) when
+	 * this process is not inside a run, the run row/ledger is unavailable
+	 * (half-migrated schema), or the run's ceiling is 0/disabled.
+	 *
+	 * @param string                                            $model    Model identifier.
+	 * @param array<int, array{role: string, content: string}>  $messages Chat messages (prompt-size estimate).
+	 * @param array<string, mixed>                              $options  Call options (max_tokens).
+	 * @return array{run_id: string, amount: float}|null Open reservation, or null when ungoverned.
+	 * @throws PRAutoBlogger_Cost_Ceiling_Exception When the reservation would breach the ceiling
+	 *                                              (the run is already halted when this throws).
+	 */
+	public static function open_chat_reservation( string $model, array $messages, array $options ): ?array {
+		return self::open_amount_reservation(
+			self::estimate_chat_cost( $model, $messages, $options ),
+			'llm:' . $model
+		);
+	}
+
+	/**
+	 * Reserve a pre-computed worst-case amount (e.g. a curl_multi image
+	 * batch's summed estimate) for the process's current run.
+	 *
+	 * @param float  $amount_usd Worst-case cost estimate in USD.
+	 * @param string $context    Short label for logs ('llm:<model>', 'image_batch').
+	 * @return array{run_id: string, amount: float}|null Open reservation, or null when ungoverned.
+	 * @throws PRAutoBlogger_Cost_Ceiling_Exception When the reservation would breach the ceiling.
+	 */
+	public static function open_amount_reservation( float $amount_usd, string $context ): ?array {
+		$run_id = PRAutoBlogger_Run_Context::current_run_id();
+		if ( null === $run_id || '' === $run_id || $amount_usd <= 0 ) {
+			return null;
+		}
+		if ( ! PRAutoBlogger_Run_State::is_available() ) {
+			return null; // Half-migrated schema — degrade to historical behavior.
+		}
+
+		PRAutoBlogger_Run_State::ensure_run( $run_id );
+		$run = PRAutoBlogger_Run_State::get_run( $run_id );
+		if ( null === $run ) {
+			return null;
+		}
+		if ( (float) $run['ceiling_usd'] <= 0 ) {
+			return null; // Ceiling disabled for this run.
+		}
+
+		if ( self::reserve( $run_id, $amount_usd ) ) {
+			return array(
+				'run_id' => $run_id,
+				'amount' => $amount_usd,
+			);
+		}
+
+		self::on_breach( $run_id, $amount_usd, $context );
+		return null; // Unreachable — on_breach always throws.
+	}
+
+	/**
+	 * Settle an open reservation to the call's actual cost: the hold is
+	 * released and the actual amount moves to settled_usd.
+	 *
+	 * @param array{run_id: string, amount: float}|null $reservation Reservation from open_*(), or null (no-op).
+	 * @param float                                     $actual_usd  Actual cost of the call.
+	 * @return void
+	 */
+	public static function settle( ?array $reservation, float $actual_usd ): void {
+		if ( null === $reservation || ! PRAutoBlogger_Run_State::is_available() ) {
+			return;
+		}
+		global $wpdb;
+		$table = PRAutoBlogger_Run_State::table_name();
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$wpdb->query(
+			$wpdb->prepare(
+				"UPDATE {$table}
+				SET reserved_usd = GREATEST(reserved_usd - %f, 0),
+					settled_usd = settled_usd + %f,
+					updated_at = %s
+				WHERE run_id = %s",
+				$reservation['amount'],
+				max( $actual_usd, 0 ),
+				current_time( 'mysql' ),
+				$reservation['run_id']
+			)
+		);
+	}
+
+	/**
+	 * Release an open reservation without settling cost (failed call).
+	 *
+	 * @param array{run_id: string, amount: float}|null $reservation Reservation from open_*(), or null (no-op).
+	 * @return void
+	 */
+	public static function release( ?array $reservation ): void {
+		self::settle( $reservation, 0.0 );
+	}
+
+	/**
+	 * Worst-case cost estimate for a chat call: estimated prompt tokens
+	 * (message chars / 4) plus the call's max_tokens completion budget,
+	 * priced via the #18 pricing chain (hardcoded table -> cached model
+	 * registry -> conservative fallback).
+	 *
+	 * @param string                                           $model    Model identifier.
+	 * @param array<int, array{role: string, content: string}> $messages Chat messages.
+	 * @param array<string, mixed>                             $options  Call options.
+	 * @return float Estimated worst-case USD cost.
+	 */
+	public static function estimate_chat_cost( string $model, array $messages, array $options ): float {
+		$chars = 0;
+		foreach ( $messages as $message ) {
+			$chars += strlen( (string) ( $message['content'] ?? '' ) );
+		}
+		$prompt_tokens     = (int) ceil( $chars / self::CHARS_PER_TOKEN );
+		$completion_tokens = (int) ( $options['max_tokens'] ?? self::DEFAULT_MAX_COMPLETION_TOKENS );
+
+		return ( new PRAutoBlogger_OpenRouter_Pricing() )->estimate_cost( $model, $prompt_tokens, $completion_tokens );
+	}
+
+	/**
+	 * Atomic conditional reservation — the #10 discipline. One UPDATE
+	 * whose WHERE clause enforces `settled + reserved + estimate <=
+	 * ceiling` AND that the run is still open; affected-rows tells us who
+	 * won. Concurrent reservers serialize on the row lock.
+	 *
+	 * @param string $run_id Run UUID.
+	 * @param float  $amount Estimate to reserve.
+	 * @return bool True when the reservation was written.
+	 */
+	private static function reserve( string $run_id, float $amount ): bool {
+		global $wpdb;
+		$table = PRAutoBlogger_Run_State::table_name();
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$updated = $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE {$table}
+				SET reserved_usd = reserved_usd + %f, updated_at = %s
+				WHERE run_id = %s
+					AND status IN ('pending','running')
+					AND (reserved_usd + settled_usd + %f) <= ceiling_usd",
+				$amount,
+				current_time( 'mysql' ),
+				$run_id,
+				$amount
+			)
+		);
+		return 1 === (int) $updated;
+	}
+
+	/**
+	 * Handle a failed reservation: halt the run (sticky), record the
+	 * overage, log, throw. The Review Queue lists halted runs; chained
+	 * queue jobs abort via the run-status check.
+	 *
+	 * @param string $run_id  Run UUID.
+	 * @param float  $amount  The estimate that failed to reserve.
+	 * @param string $context Short label for logs.
+	 * @return void
+	 * @throws PRAutoBlogger_Cost_Ceiling_Exception Always.
+	 */
+	private static function on_breach( string $run_id, float $amount, string $context ): void {
+		$run      = PRAutoBlogger_Run_State::get_run( $run_id );
+		$ceiling  = null !== $run ? (float) $run['ceiling_usd'] : 0.0;
+		$held     = null !== $run ? (float) $run['reserved_usd'] + (float) $run['settled_usd'] : 0.0;
+		$overage  = max( ( $held + $amount ) - $ceiling, 0.0 );
+
+		PRAutoBlogger_Run_State::mark_status( $run_id, 'halted' );
+		PRAutoBlogger_Run_State::record_overage( $run_id, $overage );
+
+		$message = sprintf(
+			/* translators: 1: blocked amount USD, 2: call context, 3: committed USD, 4: ceiling USD, 5: run id. */
+			__( 'Per-run cost ceiling reached: reserving $%1$.4f for %2$s would push the run to $%3$.4f against a $%4$.2f ceiling. Run %5$s halted and routed to the Review Queue.', 'prautoblogger' ),
+			$amount,
+			$context,
+			$held + $amount,
+			$ceiling,
+			$run_id
+		);
+
+		PRAutoBlogger_Logger::instance()->error( $message, 'cost-governor' );
+
+		throw new PRAutoBlogger_Cost_Ceiling_Exception( $message );
+	}
+}

--- a/includes/core/class-cost-reporter.php
+++ b/includes/core/class-cost-reporter.php
@@ -140,4 +140,62 @@ class PRAutoBlogger_Cost_Reporter {
 		}
 		return ( $this->get_monthly_spend() / $budget ) * 100.0;
 	}
+	/**
+	 * Get average input/output token counts for given stages over a time period.
+	 *
+	 * Used by the model picker field renderer to calculate estimated costs
+	 * per generation based on historical token usage. Maps setting IDs to their
+	 * constituting stages (e.g., writing model controls outline + draft + polish).
+	 * Moved here from Cost_Tracker in v0.18.0 (read-only reporting query;
+	 * Cost_Tracker keeps a delegating wrapper for API compatibility).
+	 *
+	 * @param array<string> $stages Stage names ('analysis', 'outline', 'draft', 'polish', 'review').
+	 * @param int           $days   Historical window (default 30 days).
+	 *
+	 * @return array{avg_prompt_tokens: float, avg_completion_tokens: float, sample_size: int}
+	 *         Returns empty counters if no history. Never throws.
+	 */
+	public function get_avg_tokens_for_stages( array $stages, int $days = 30 ): array {
+		global $wpdb;
+
+		if ( empty( $stages ) ) {
+			return array(
+				'avg_prompt_tokens'      => 0.0,
+				'avg_completion_tokens'  => 0.0,
+				'sample_size'            => 0,
+			);
+		}
+
+		$cutoff_datetime = gmdate( 'Y-m-d H:i:s', time() - ( $days * DAY_IN_SECONDS ) );
+		$stage_list      = implode( ',', array_map( array( $wpdb, 'prepare' ), array_fill( 0, count( $stages ), '%s' ), $stages ) );
+		$table_name      = $wpdb->prefix . 'prautoblogger_generation_log';
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Prepared stage list via array_map + prepare
+		$query = $wpdb->prepare(
+			"SELECT AVG(prompt_tokens) as avg_prompt,
+                    AVG(completion_tokens) as avg_completion,
+                    COUNT(*) as sample_count
+             FROM $table_name
+             WHERE stage IN ( $stage_list )
+             AND created_at >= %s",
+			$cutoff_datetime
+		);
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- phpcs pragma above
+		$result = $wpdb->get_row( $query, ARRAY_A );
+
+		if ( ! $result || 0 === (int) ( $result['sample_count'] ?? 0 ) ) {
+			return array(
+				'avg_prompt_tokens'      => 0.0,
+				'avg_completion_tokens'  => 0.0,
+				'sample_size'            => 0,
+			);
+		}
+
+		return array(
+			'avg_prompt_tokens'      => (float) ( $result['avg_prompt'] ?? 0 ),
+			'avg_completion_tokens'  => (float) ( $result['avg_completion'] ?? 0 ),
+			'sample_size'            => (int) ( $result['sample_count'] ?? 0 ),
+		);
+	}
 }

--- a/includes/core/class-cost-tracker.php
+++ b/includes/core/class-cost-tracker.php
@@ -127,9 +127,19 @@ class PRAutoBlogger_Cost_Tracker {
 		$table = $wpdb->prefix . 'prautoblogger_generation_log';
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
-		$wpdb->insert( $table, $log_entry->to_db_row() );
+		$inserted = $wpdb->insert( $table, $log_entry->to_db_row() );
 
-		if ( false === $wpdb->insert_id ) {
+		// Self-healing on a half-migrated schema (e.g. cron fires after a
+		// deploy but before any admin_init migration pass): retry without
+		// the v0.18.0 audit columns rather than losing the cost row.
+		if ( false === $inserted ) {
+			$legacy_row = $log_entry->to_db_row();
+			unset( $legacy_row['agent_role'], $legacy_row['prompt_version'] );
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+			$inserted = $wpdb->insert( $table, $legacy_row );
+		}
+
+		if ( false === $inserted || false === $wpdb->insert_id ) {
 			PRAutoBlogger_Logger::instance()->error( 'Failed to log API call: ' . $wpdb->last_error, 'cost-tracker' );
 		}
 	}
@@ -179,25 +189,31 @@ class PRAutoBlogger_Cost_Tracker {
 		}
 		$table = $wpdb->prefix . 'prautoblogger_generation_log';
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
-		$wpdb->insert(
-			$table,
-			array(
-				'post_id'           => $post_id,
-				'run_id'            => $this->run_id,
-				'stage'             => $stage,
-				'provider'          => 'cloudflare-workers-ai',
-				'model'             => $model,
-				'prompt_tokens'     => 0,
-				'completion_tokens' => 0,
-				'estimated_cost'    => $cost_usd,
-				'response_status'   => 'success',
-				'error_message'     => '',
-				'agent_role'        => PRAutoBlogger_Stage_Display_Map::default_agent_role( $stage ),
-				'prompt_version'    => $this->resolve_prompt_version( $stage, null ),
-				'created_at'        => current_time( 'mysql' ),
-			)
+		$row = array(
+			'post_id'           => $post_id,
+			'run_id'            => $this->run_id,
+			'stage'             => $stage,
+			'provider'          => 'cloudflare-workers-ai',
+			'model'             => $model,
+			'prompt_tokens'     => 0,
+			'completion_tokens' => 0,
+			'estimated_cost'    => $cost_usd,
+			'response_status'   => 'success',
+			'error_message'     => '',
+			'agent_role'        => PRAutoBlogger_Stage_Display_Map::default_agent_role( $stage ),
+			'prompt_version'    => $this->resolve_prompt_version( $stage, null ),
+			'created_at'        => current_time( 'mysql' ),
 		);
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$inserted = $wpdb->insert( $table, $row );
+
+		// Self-healing on a half-migrated schema — see log_api_call().
+		if ( false === $inserted ) {
+			unset( $row['agent_role'], $row['prompt_version'] );
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+			$wpdb->insert( $table, $row );
+		}
 	}
 
 	/**

--- a/includes/core/class-cost-tracker.php
+++ b/includes/core/class-cost-tracker.php
@@ -47,6 +47,14 @@ class PRAutoBlogger_Cost_Tracker {
 	 */
 	public function set_run_id( string $run_id ): void {
 		$this->run_id = $run_id;
+		// v0.18.0: declaring a run id makes this PHP process part of that
+		// run — record the context (cost-governor guard, prompt-version
+		// stamping for components without a run reference), make sure the
+		// run ledger row exists, and pin the active prompt versions once.
+		// All three are self-healing no-ops on a half-migrated schema.
+		PRAutoBlogger_Run_Context::set_run_id( $run_id );
+		PRAutoBlogger_Run_State::ensure_run( $run_id );
+		PRAutoBlogger_Prompt_Registry::pin_for_run( $run_id );
 	}
 
 	/**
@@ -63,14 +71,20 @@ class PRAutoBlogger_Cost_Tracker {
 	 *
 	 * Side effects: database insert into prab_generation_log.
 	 *
-	 * @param int|null $post_id           WordPress post ID (null during generation, set later).
-	 * @param string   $stage             Pipeline stage: 'analysis', 'outline', 'draft', 'polish', 'review'.
-	 * @param string   $provider          Provider name: 'OpenRouter'.
-	 * @param string   $model             Model identifier used.
-	 * @param int      $prompt_tokens     Input tokens consumed.
-	 * @param int      $completion_tokens Output tokens generated.
-	 * @param string   $response_status   'success', 'error', or 'timeout'.
-	 * @param string   $error_message     Error details if status is not 'success'.
+	 * @param int|null    $post_id           WordPress post ID (null during generation, set later).
+	 * @param string      $stage             Pipeline stage (see PRAutoBlogger_Stage_Display_Map).
+	 * @param string      $provider          Provider name: 'OpenRouter'.
+	 * @param string      $model             Model identifier used.
+	 * @param int         $prompt_tokens     Input tokens consumed.
+	 * @param int         $completion_tokens Output tokens generated.
+	 * @param string      $response_status   'success', 'error', or 'timeout'.
+	 * @param string      $error_message     Error details if status is not 'success'.
+	 * @param string|null $agent_role        v0.18.0 — role that made the call; derived
+	 *                                       from the stage map when null.
+	 * @param string|null $prompt_key        v0.18.0 — registry key the call rendered
+	 *                                       with (e.g. 'content.single_pass'); derived
+	 *                                       from the stage map when null. Resolves the
+	 *                                       run-pinned prompt_version stamped on the row.
 	 *
 	 * @return void
 	 */
@@ -82,7 +96,9 @@ class PRAutoBlogger_Cost_Tracker {
 		int $prompt_tokens,
 		int $completion_tokens,
 		string $response_status = 'success',
-		string $error_message = ''
+		string $error_message = '',
+		?string $agent_role = null,
+		?string $prompt_key = null
 	): void {
 		$llm  = new PRAutoBlogger_OpenRouter_Provider();
 		$cost = $llm->estimate_cost( $model, $prompt_tokens, $completion_tokens );
@@ -101,6 +117,8 @@ class PRAutoBlogger_Cost_Tracker {
 				'estimated_cost'    => $cost,
 				'response_status'   => $response_status,
 				'error_message'     => $error_message,
+				'agent_role'        => $agent_role ?? PRAutoBlogger_Stage_Display_Map::default_agent_role( $stage ),
+				'prompt_version'    => $this->resolve_prompt_version( $stage, $prompt_key ),
 				'created_at'        => current_time( 'mysql' ),
 			)
 		);
@@ -175,9 +193,35 @@ class PRAutoBlogger_Cost_Tracker {
 				'estimated_cost'    => $cost_usd,
 				'response_status'   => 'success',
 				'error_message'     => '',
+				'agent_role'        => PRAutoBlogger_Stage_Display_Map::default_agent_role( $stage ),
+				'prompt_version'    => $this->resolve_prompt_version( $stage, null ),
 				'created_at'        => current_time( 'mysql' ),
 			)
 		);
+	}
+
+	/**
+	 * Resolve the pinned prompt version to stamp on a log row.
+	 *
+	 * Uses the explicit registry key when the call site passed one,
+	 * otherwise the stage's primary key from the display map. The version
+	 * comes from the run's pins; the run is this tracker's run_id or —
+	 * for standalone trackers inside a pipeline process (e.g. the image
+	 * prompt rewriter's) — the process-level run context. Null when there
+	 * is no run, no pins, or no key (historical behavior preserved).
+	 *
+	 * @param string      $stage      Stage being logged.
+	 * @param string|null $prompt_key Explicit registry key, or null to derive.
+	 * @return string|null Pinned version as string, or null.
+	 */
+	private function resolve_prompt_version( string $stage, ?string $prompt_key ): ?string {
+		$key = $prompt_key ?? PRAutoBlogger_Stage_Display_Map::default_prompt_key( $stage );
+		if ( null === $key ) {
+			return null;
+		}
+		$run_id = $this->run_id ?? PRAutoBlogger_Run_Context::current_run_id();
+		$pins   = PRAutoBlogger_Prompt_Registry::pins_for_run( $run_id );
+		return isset( $pins[ $key ] ) ? (string) $pins[ $key ] : null;
 	}
 
 	/**
@@ -214,9 +258,9 @@ class PRAutoBlogger_Cost_Tracker {
 	/**
 	 * Get average input/output token counts for given stages over a time period.
 	 *
-	 * Used by the model picker field renderer to calculate estimated costs
-	 * per generation based on historical token usage. Maps setting IDs to their
-	 * constituting stages (e.g., writing model controls outline + draft + polish).
+	 * Thin delegate to PRAutoBlogger_Cost_Reporter (the read-only reporting
+	 * class) — kept here for API compatibility with the model-picker field
+	 * and existing tests. See Cost_Reporter for the query.
 	 *
 	 * @param array<string> $stages Stage names ('analysis', 'outline', 'draft', 'polish', 'review').
 	 * @param int           $days   Historical window (default 30 days).
@@ -225,46 +269,6 @@ class PRAutoBlogger_Cost_Tracker {
 	 *         Returns empty counters if no history. Never throws.
 	 */
 	public function get_avg_tokens_for_stages( array $stages, int $days = 30 ): array {
-		global $wpdb;
-
-		if ( empty( $stages ) ) {
-			return array(
-				'avg_prompt_tokens'      => 0.0,
-				'avg_completion_tokens'  => 0.0,
-				'sample_size'            => 0,
-			);
-		}
-
-		$cutoff_datetime = gmdate( 'Y-m-d H:i:s', time() - ( $days * DAY_IN_SECONDS ) );
-		$stage_list      = implode( ',', array_map( array( $wpdb, 'prepare' ), array_fill( 0, count( $stages ), '%s' ), $stages ) );
-		$table_name      = $wpdb->prefix . 'prautoblogger_generation_log';
-
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Prepared stage list via array_map + prepare
-		$query = $wpdb->prepare(
-			"SELECT AVG(prompt_tokens) as avg_prompt,
-                    AVG(completion_tokens) as avg_completion,
-                    COUNT(*) as sample_count
-             FROM $table_name
-             WHERE stage IN ( $stage_list )
-             AND created_at >= %s",
-			$cutoff_datetime
-		);
-
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- phpcs pragma above
-		$result = $wpdb->get_row( $query, ARRAY_A );
-
-		if ( ! $result || 0 === (int) ( $result['sample_count'] ?? 0 ) ) {
-			return array(
-				'avg_prompt_tokens'      => 0.0,
-				'avg_completion_tokens'  => 0.0,
-				'sample_size'            => 0,
-			);
-		}
-
-		return array(
-			'avg_prompt_tokens'      => (float) ( $result['avg_prompt'] ?? 0 ),
-			'avg_completion_tokens'  => (float) ( $result['avg_completion'] ?? 0 ),
-			'sample_size'            => (int) ( $result['sample_count'] ?? 0 ),
-		);
+		return ( new PRAutoBlogger_Cost_Reporter() )->get_avg_tokens_for_stages( $stages, $days );
 	}
 }

--- a/includes/core/class-image-pipeline.php
+++ b/includes/core/class-image-pipeline.php
@@ -125,6 +125,16 @@ class PRAutoBlogger_Image_Pipeline {
 			return $result;
 		}
 
+		// v0.18.0 — per-run governor: reserve the curl_multi batch's SUMMED
+		// worst-case estimate before dispatch (no-op outside a governed
+		// run). A breach halts the run and skips the whole batch.
+		try {
+			$batch_reservation = PRAutoBlogger_Cost_Governor::open_amount_reservation( $estimated_cost, 'image_batch' );
+		} catch ( PRAutoBlogger_Cost_Ceiling_Exception $e ) {
+			$result['errors'][] = $e->getMessage();
+			return $result;
+		}
+
 		// Build all prompts upfront (LLM calls happen here, sequentially).
 		$article_prompt = $this->prompt_builder->build_article_prompt( $article_data );
 		$batch_requests = array(
@@ -151,10 +161,18 @@ class PRAutoBlogger_Image_Pipeline {
 		try {
 			$batch_results = $this->provider->generate_image_batch( $batch_requests );
 		} catch ( \Throwable $e ) {
+			PRAutoBlogger_Cost_Governor::release( $batch_reservation );
 			PRAutoBlogger_Logger::instance()->error( 'Batch generation failed: ' . $e->getMessage(), 'image_pipeline' );
 			$result['errors'][] = $e->getMessage();
 			return $result;
 		}
+
+		// Settle the batch reservation to the actual per-image costs.
+		$actual_batch_cost = 0.0;
+		foreach ( $batch_results as $batch_entry ) {
+			$actual_batch_cost += (float) ( $batch_entry['cost_usd'] ?? 0 );
+		}
+		PRAutoBlogger_Cost_Governor::settle( $batch_reservation, $actual_batch_cost );
 
 		// Single-shot retry for any slot the provider flagged as NSFW-blocked.
 		if ( PRAutoBlogger_Image_NSFW_Retry::is_enabled() ) {

--- a/includes/core/class-pipeline-runner.php
+++ b/includes/core/class-pipeline-runner.php
@@ -65,6 +65,7 @@ class PRAutoBlogger_Pipeline_Runner {
 
 		$ideas = $this->orchestrate( $cost_tracker );
 		if ( empty( $ideas ) ) {
+			PRAutoBlogger_Run_State::mark_status( (string) $cost_tracker->get_run_id(), 'done' );
 			return array(
 				'generated' => 0,
 				'published' => 0,
@@ -84,7 +85,8 @@ class PRAutoBlogger_Pipeline_Runner {
 		} else {
 			// Single-article run — amortize research costs now (1 article = full cost).
 			PRAutoBlogger_Post_Assembler::amortize_research_costs( $cost_tracker->get_run_id() );
-			$this->log_summary( $result );
+			PRAutoBlogger_Pipeline_Status::log_summary( $result );
+			PRAutoBlogger_Run_State::mark_status( (string) $cost_tracker->get_run_id(), 'done' );
 		}
 
 		return $result;
@@ -115,6 +117,7 @@ class PRAutoBlogger_Pipeline_Runner {
 				'Budget limit reached. Aborting remaining queued articles.',
 				'pipeline'
 			);
+			PRAutoBlogger_Run_State::mark_status( (string) $queue['run_id'], 'failed' );
 			$this->finish_queue();
 			return;
 		}
@@ -152,15 +155,16 @@ class PRAutoBlogger_Pipeline_Runner {
 
 		if ( ! empty( $queue['ideas'] ) ) {
 			update_option( self::QUEUE_KEY, $queue, false );
-			$this->update_queue_status( $queue );
+			PRAutoBlogger_Pipeline_Status::update_queue_progress( $queue );
 			$this->schedule_next();
 		} else {
 			// All articles done — amortize shared research costs across them.
 			PRAutoBlogger_Post_Assembler::amortize_research_costs( $queue['run_id'] );
-			$this->write_final_status( $queue['results'] );
+			PRAutoBlogger_Pipeline_Status::write_final( $queue['results'] );
 			delete_option( self::QUEUE_KEY );
 			PRAutoBlogger_Generation_Lock::release();
-			$this->log_summary( $queue['results'] );
+			PRAutoBlogger_Pipeline_Status::log_summary( $queue['results'] );
+			PRAutoBlogger_Run_State::mark_status( (string) $queue['run_id'], 'done' );
 		}
 	}
 
@@ -175,20 +179,26 @@ class PRAutoBlogger_Pipeline_Runner {
 	private function orchestrate( PRAutoBlogger_Cost_Tracker $cost_tracker ): array {
 		$target = absint( get_option( 'prautoblogger_daily_article_target', 1 ) );
 
+		$run_id = (string) $cost_tracker->get_run_id();
+
 		$enabled       = json_decode( get_option( 'prautoblogger_enabled_sources', '["reddit"]' ), true );
 		$source_labels = is_array( $enabled ) ? implode( ', ', $enabled ) : 'reddit';
 		/* translators: %s is a comma-separated list of enabled source names, e.g. "reddit, llm_research". */
-		$this->broadcast_stage( sprintf( __( 'Collecting sources from %s…', 'prautoblogger' ), $source_labels ) );
+		PRAutoBlogger_Pipeline_Status::broadcast( sprintf( __( 'Collecting sources from %s…', 'prautoblogger' ), $source_labels ) );
+		PRAutoBlogger_Run_Stage_State::start( $run_id, 'research' );
 		( new PRAutoBlogger_Source_Collector() )
 			->set_cost_tracker( $cost_tracker )
 			->collect_from_all_sources();
+		PRAutoBlogger_Run_Stage_State::done( $run_id, 'research' );
 
-		$this->broadcast_stage( __( 'Analyzing topics and scoring…', 'prautoblogger' ) );
+		PRAutoBlogger_Pipeline_Status::broadcast( __( 'Analyzing topics and scoring…', 'prautoblogger' ) );
+		PRAutoBlogger_Run_Stage_State::start( $run_id, 'analysis' );
 		$llm      = new PRAutoBlogger_OpenRouter_Provider();
 		$analyzer = new PRAutoBlogger_Content_Analyzer( $llm, $cost_tracker );
 		$analysis = $analyzer->analyze_recent_data( max( $target * 2, 6 ) );
+		PRAutoBlogger_Run_Stage_State::done( $run_id, 'analysis' );
 
-		$this->broadcast_stage( __( 'Selecting best topic…', 'prautoblogger' ) );
+		PRAutoBlogger_Pipeline_Status::broadcast( __( 'Selecting best topic…', 'prautoblogger' ) );
 		$scorer = new PRAutoBlogger_Idea_Scorer();
 		$scorer->set_skip_dedup( $this->skip_dedup );
 		$ideas = $scorer->score_and_rank( $analysis, $target );
@@ -223,7 +233,7 @@ class PRAutoBlogger_Pipeline_Runner {
 		);
 
 		update_option( self::QUEUE_KEY, $queue, false );
-		$this->update_queue_status( $queue );
+		PRAutoBlogger_Pipeline_Status::update_queue_progress( $queue );
 		$this->schedule_next();
 
 		PRAutoBlogger_Logger::instance()->info(
@@ -248,71 +258,13 @@ class PRAutoBlogger_Pipeline_Runner {
 		);
 	}
 
-	/** Update the frontend status transient with queue progress. */
-	private function update_queue_status( array $queue ): void {
-		$done  = $queue['results']['generated'] + $queue['results']['rejected'];
-		$total = $done + count( $queue['ideas'] );
-
-		$current = get_transient( 'prautoblogger_generation_status' );
-		set_transient(
-			'prautoblogger_generation_status',
-			array(
-				'status'       => 'running',
-				'stage'        => sprintf( __( 'Generating article %1$d of %2$d…', 'prautoblogger' ), $done + 1, $total ),
-				'started'      => is_array( $current ) ? ( $current['started'] ?? time() ) : time(),
-				'last_updated' => time(),
-			),
-			600
-		);
-	}
-
-	/** Write the final "complete" status transient. */
-	private function write_final_status( array $r ): void {
-		set_transient(
-			'prautoblogger_generation_status',
-			array(
-				'status'    => 'complete',
-				'generated' => $r['generated'],
-				'published' => $r['published'],
-				'rejected'  => $r['rejected'],
-				'cost'      => $r['cost'],
-			),
-			600
-		);
-	}
-
 	/** Clean up a stale or empty queue. */
 	private function finish_queue(): void {
 		$queue = get_option( self::QUEUE_KEY );
 		if ( is_array( $queue ) && isset( $queue['results'] ) ) {
-			$this->write_final_status( $queue['results'] );
+			PRAutoBlogger_Pipeline_Status::write_final( $queue['results'] );
 		}
 		delete_option( self::QUEUE_KEY );
 		PRAutoBlogger_Generation_Lock::release();
-	}
-
-	/** Log the pipeline summary. */
-	private function log_summary( array $r ): void {
-		PRAutoBlogger_Logger::instance()->info(
-			sprintf(
-				'Pipeline complete: %d generated, %d published, %d rejected. Cost: $%.4f',
-				$r['generated'],
-				$r['published'],
-				$r['rejected'],
-				$r['cost']
-			),
-			'pipeline'
-		);
-	}
-
-	/** Update the generation status transient with the current stage. */
-	private function broadcast_stage( string $stage ): void {
-		$key     = 'prautoblogger_generation_status';
-		$current = get_transient( $key );
-		if ( is_array( $current ) && 'running' === ( $current['status'] ?? '' ) ) {
-			$current['stage']        = $stage;
-			$current['last_updated'] = time();
-			set_transient( $key, $current, 600 );
-		}
 	}
 }

--- a/includes/core/class-pipeline-runner.php
+++ b/includes/core/class-pipeline-runner.php
@@ -119,6 +119,18 @@ class PRAutoBlogger_Pipeline_Runner {
 			return;
 		}
 
+		// v0.18.0 — a run halted by the per-run cost governor (or failed by
+		// the reaper) must not dispatch its remaining queued articles.
+		$run_status = PRAutoBlogger_Run_State::get_status( $queue['run_id'] );
+		if ( in_array( $run_status, array( 'halted', 'failed' ), true ) ) {
+			PRAutoBlogger_Logger::instance()->warning(
+				sprintf( 'Run %s is %s. Aborting remaining queued articles.', $queue['run_id'], $run_status ),
+				'pipeline'
+			);
+			$this->finish_queue();
+			return;
+		}
+
 		// Persist the consumed queue BEFORE generating so the status poller
 		// cannot re-schedule a cron event for the same idea. Without this,
 		// the DB still holds the old queue during the ~90s generation window,

--- a/includes/core/class-pipeline-status.php
+++ b/includes/core/class-pipeline-status.php
@@ -1,0 +1,106 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * phpcs:ignore WordPress.Files.FileName.InvalidClassFileName -- class naming convention differs from WordPress standard
+ *
+ * Frontend status-transient + summary-log helpers for pipeline runs.
+ *
+ * What: The generation-status transient plumbing (stage broadcast, queue
+ *       progress, final result) and the pipeline summary log line,
+ *       extracted verbatim from Pipeline_Runner / Article_Worker in
+ *       v0.18.0 (300-line cap; the two classes carried duplicate
+ *       broadcast helpers). Pure presentation/state — no business logic.
+ * Who triggers it: Pipeline_Runner, Article_Worker.
+ * Dependencies: WordPress transients, PRAutoBlogger_Logger.
+ *
+ * @see core/class-pipeline-runner.php — Queue progress + final status writes.
+ * @see core/class-article-worker.php  — Per-stage broadcasts.
+ * @see class-executor.php             — Poller that reads this transient.
+ */
+class PRAutoBlogger_Pipeline_Status {
+
+	/** Transient key polled by the admin frontend. */
+	private const KEY = 'prautoblogger_generation_status';
+
+	/** Seconds the status transient stays readable. */
+	private const TTL = 600;
+
+	/**
+	 * Update the live stage text (only while a run is broadcasting).
+	 *
+	 * @param string $stage Human-readable stage description.
+	 * @return void
+	 */
+	public static function broadcast( string $stage ): void {
+		$current = get_transient( self::KEY );
+		if ( is_array( $current ) && 'running' === ( $current['status'] ?? '' ) ) {
+			$current['stage']        = $stage;
+			$current['last_updated'] = time();
+			set_transient( self::KEY, $current, self::TTL );
+		}
+	}
+
+	/**
+	 * Update queue progress ("Generating article X of Y…").
+	 *
+	 * @param array $queue Queue array with 'results' + 'ideas'.
+	 * @return void
+	 */
+	public static function update_queue_progress( array $queue ): void {
+		$done  = $queue['results']['generated'] + $queue['results']['rejected'];
+		$total = $done + count( $queue['ideas'] );
+
+		$current = get_transient( self::KEY );
+		set_transient(
+			self::KEY,
+			array(
+				'status'       => 'running',
+				/* translators: 1: current article number, 2: total articles. */
+				'stage'        => sprintf( __( 'Generating article %1$d of %2$d…', 'prautoblogger' ), $done + 1, $total ),
+				'started'      => is_array( $current ) ? ( $current['started'] ?? time() ) : time(),
+				'last_updated' => time(),
+			),
+			self::TTL
+		);
+	}
+
+	/**
+	 * Write the final "complete" status.
+	 *
+	 * @param array $r Result counters (generated/published/rejected/cost).
+	 * @return void
+	 */
+	public static function write_final( array $r ): void {
+		set_transient(
+			self::KEY,
+			array(
+				'status'    => 'complete',
+				'generated' => $r['generated'],
+				'published' => $r['published'],
+				'rejected'  => $r['rejected'],
+				'cost'      => $r['cost'],
+			),
+			self::TTL
+		);
+	}
+
+	/**
+	 * Log the pipeline summary line.
+	 *
+	 * @param array $r Result counters (generated/published/rejected/cost).
+	 * @return void
+	 */
+	public static function log_summary( array $r ): void {
+		PRAutoBlogger_Logger::instance()->info(
+			sprintf(
+				'Pipeline complete: %d generated, %d published, %d rejected. Cost: $%.4f',
+				$r['generated'],
+				$r['published'],
+				$r['rejected'],
+				$r['cost']
+			),
+			'pipeline'
+		);
+	}
+}

--- a/includes/core/class-prompt-defaults-editorial.php
+++ b/includes/core/class-prompt-defaults-editorial.php
@@ -1,0 +1,147 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * phpcs:ignore WordPress.Files.FileName.InvalidClassFileName -- class naming convention differs from WordPress standard
+ *
+ * Canonical default bodies for the editor, research, and image registry keys.
+ *
+ * What: Companion to PRAutoBlogger_Prompt_Defaults (split for the 300-line
+ *       cap, mirroring the settings-fields/-extended split). Holds the
+ *       chief-editor and LLM-research prompt copy extracted verbatim from
+ *       their classes, and references the two image keys that form the
+ *       image-composer PR seam: `image.rewriter_system` (the illustration
+ *       rewriter prompt) and `image.style_template` (the Style Template,
+ *       ARCHITECTURE #20). The composer PR CONSUMES these keys — it must
+ *       not grow its own prompt storage, and the key names are frozen on
+ *       the pipeline-v2-phase1 convo thread.
+ * Who triggers it: PRAutoBlogger_Prompt_Registry (render fallback + seed),
+ *       PRAutoBlogger_Activator (seed migration).
+ * Dependencies: PRAutoBlogger_Image_Prompt_Builder::REWRITER_SYSTEM_PROMPT,
+ *       PRAUTOBLOGGER_DEFAULT_IMAGE_STYLE_TEMPLATE (referenced, not duplicated).
+ *
+ * @see core/class-prompt-defaults.php   — Content + analysis keys.
+ * @see core/class-prompt-registry.php   — Render/seed consumer.
+ * @see core/class-chief-editor.php      — Computes the editor token values.
+ * @see providers/class-llm-research-provider.php — research.system consumer.
+ */
+class PRAutoBlogger_Prompt_Defaults_Editorial {
+
+	/**
+	 * Chief-editor system prompt. instructions_block carries its own
+	 * leading newline + trailing newline when non-empty ('' when absent),
+	 * matching the historical concatenation byte-for-byte.
+	 */
+	public const EDITOR_SYSTEM = <<<'TPL'
+You are a senior blog editor{{ niche_clause }}. Review article drafts before publication.
+
+Evaluate on: QUALITY, ACCURACY, SEO, COMPLETENESS, READABILITY.
+Respond with JSON: {
+  "verdict": "approved" | "revised" | "rejected",
+  "quality_score": 0.0-1.0,
+  "seo_score": 0.0-1.0,
+  "issues": ["issue1", "issue2"],
+  "notes": "Editorial notes",
+  "revised_content": "Full revised HTML if revised, null otherwise"
+}
+
+Rules:
+- APPROVE if quality_score >= 0.7 and seo_score >= 0.6
+- REVISE if fixable issues exist — provide full revised HTML
+- REJECT if fundamentally flawed
+- Preserve formatting, links, lists when revising
+{{ instructions_block }}
+TPL;
+
+	/** Chief-editor review user prompt. */
+	public const EDITOR_REVIEW = <<<'TPL'
+Review this article draft:
+
+BRIEF: Title: {{ title }} | Topic: {{ topic }} | Type: {{ article_type }}
+KEY POINTS: {{ key_points }}
+TARGET KEYWORDS: {{ keywords }}
+
+CONTENT:
+{{ content }}
+TPL;
+
+	/**
+	 * LLM deep-research system prompt (fully static). The user-side
+	 * research brief stays the `prautoblogger_research_prompt` SETTING —
+	 * it is site configuration, not pipeline copy.
+	 */
+	public const RESEARCH_SYSTEM = <<<'TPL'
+You are a deep research analyst specializing in emerging trends, scientific developments, and community knowledge in niche health and biohacking domains. Your task is to identify substantive, actionable findings.
+
+Using your training knowledge, scan across:
+- Recent scientific literature and research directions
+- Active community discussions, debates, and evolving consensus
+- Emerging products, protocols, and methodologies gaining traction
+- Common questions, misconceptions, and points of confusion
+- Regulatory changes, safety concerns, and legal shifts
+- Gaps between what practitioners want to know and what content exists
+
+Your findings must be:
+1. SUBSTANTIVE — 2-3 paragraphs of detailed analysis per finding, not a headline
+2. ACTIONABLE — practical enough to seed a full article
+3. REALISTIC — grounded in what is actually discussed or researched; do NOT invent citations
+4. TIMELY — reflect current knowledge, recent shifts, or emerging questions
+
+Respond with valid JSON only (no preamble, no markdown fences):
+{"findings": [{"title": "string", "content": "string (2-3 paragraphs)", "relevance_score": 0-100, "category": "question|trend|comparison|guide|misconception|safety"}]}
+
+Generate 8-12 findings. Prioritize depth over breadth. Avoid generic or surface-level topics.
+TPL;
+
+	/**
+	 * Registry definitions for the editor / research / image keys.
+	 *
+	 * The image bodies are referenced from their existing single sources
+	 * of truth rather than duplicated. Note the image keys seed the
+	 * registry for the composer PR; the v0.16.0 option-override chain
+	 * (`prautoblogger_image_prompt_instructions`,
+	 * `prautoblogger_image_style_template`) is unchanged in Phase 1.
+	 *
+	 * @return array<string, array{body: string, model_option: ?string, params: array<string, mixed>}>
+	 */
+	public static function defs(): array {
+		return array(
+			'editor.system'         => array(
+				'body'         => self::EDITOR_SYSTEM,
+				'model_option' => 'prautoblogger_editor_model',
+				'params'       => array(
+					'temperature'     => 0.3,
+					'max_tokens'      => 5000,
+					'response_format' => array( 'type' => 'json_object' ),
+				),
+			),
+			'editor.review'         => array(
+				'body'         => self::EDITOR_REVIEW,
+				'model_option' => 'prautoblogger_editor_model',
+				'params'       => array(),
+			),
+			'research.system'       => array(
+				'body'         => self::RESEARCH_SYSTEM,
+				'model_option' => 'prautoblogger_research_model',
+				'params'       => array(
+					'temperature'     => 0.7,
+					'max_tokens'      => 8000,
+					'response_format' => array( 'type' => 'json_object' ),
+				),
+			),
+			'image.rewriter_system' => array(
+				'body'         => PRAutoBlogger_Image_Prompt_Builder::REWRITER_SYSTEM_PROMPT,
+				'model_option' => 'prautoblogger_analysis_model',
+				'params'       => array(
+					'temperature' => 0.7,
+					'max_tokens'  => 180,
+				),
+			),
+			'image.style_template'  => array(
+				'body'         => PRAUTOBLOGGER_DEFAULT_IMAGE_STYLE_TEMPLATE,
+				'model_option' => 'prautoblogger_image_model',
+				'params'       => array(),
+			),
+		);
+	}
+}

--- a/includes/core/class-prompt-defaults.php
+++ b/includes/core/class-prompt-defaults.php
@@ -1,0 +1,210 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * phpcs:ignore WordPress.Files.FileName.InvalidClassFileName -- class naming convention differs from WordPress standard
+ *
+ * Canonical default bodies for the content + analysis prompt-registry keys.
+ *
+ * What: The v0.16.0 hardcoded prompt texts, extracted verbatim into
+ *       `{{ token }}` templates. These constants are the single source of
+ *       truth twice over: the v1.2.0 migration seeds them into
+ *       `wp_prautoblogger_prompts` as version 1, AND the registry falls
+ *       back to them whenever the table is missing/empty — so a
+ *       half-migrated site renders byte-identical prompts and never
+ *       fatals. Versions in the table are immutable; to change a prompt,
+ *       create a new version (see Prompt_Registry).
+ * Who triggers it: PRAutoBlogger_Prompt_Registry (render fallback + seed),
+ *       PRAutoBlogger_Activator (seed migration).
+ * Dependencies: none — pure constants.
+ *
+ * @see core/class-prompt-registry.php           — Render/seed consumer.
+ * @see core/class-prompt-defaults-editorial.php — Editor/research/image keys.
+ * @see core/class-content-prompts.php           — Computes the token values.
+ * @see core/class-analysis-prompts.php          — Computes the token values.
+ */
+class PRAutoBlogger_Prompt_Defaults {
+
+	/**
+	 * System prompt shared across all writing stages. The mandatory style
+	 * guide block and the linking rules stay code-side (they are data
+	 * injection, not prompt copy) and are appended after this body.
+	 */
+	public const CONTENT_SYSTEM = 'You are an expert blog writer{{ niche_clause }}. Write well-researched, engaging, SEO-friendly content. Use a {{ tone }} tone. Output HTML content only — no markdown, no code fences, no commentary.';
+
+	/** Single-pass writer prompt (Economy tier — logs stage 'draft'). */
+	public const CONTENT_SINGLE_PASS = <<<'TPL'
+Write a complete blog post in HTML format.
+
+Title: {{ title }}
+Topic: {{ topic }}
+Type: {{ article_type }}
+
+Key points:
+- {{ key_points }}
+
+Keywords: {{ keywords }}
+
+Requirements:
+- {{ min_words }}-{{ max_words }} words
+- Proper HTML (h2, h3, p, ul/li)
+- Engaging intro, strong conclusion with CTA
+- Do NOT include the title or <html>/<body> tags
+- Output HTML only, no markdown or commentary
+- Follow EVERY formatting and structural requirement from your system prompt style guide
+TPL;
+
+	/** Multi-step stage 1: outline. */
+	public const CONTENT_OUTLINE = <<<'TPL'
+Create a detailed outline for a blog post titled: "{{ title }}"
+
+Topic: {{ topic }}
+Article type: {{ article_type }}
+
+Key points to cover:
+{{ key_points }}
+
+Target keywords: {{ keywords }}
+
+The outline should have 4-6 main sections with bullet points under each. Include an introduction hook and a conclusion with a call to action. Word count target: {{ min_words }}-{{ max_words }} words.
+
+Plan the structure to satisfy EVERY requirement in your system prompt style guide.
+TPL;
+
+	/** Multi-step stage 2: full draft from outline. */
+	public const CONTENT_DRAFT = <<<'TPL'
+Using this outline, write the full blog post in HTML format.
+
+OUTLINE:
+{{ outline }}
+
+Requirements:
+- Write in a {{ tone }} tone
+- Target {{ min_words }}-{{ max_words }} words
+- Use proper HTML headings (h2, h3), paragraphs, and lists
+- Include an engaging introduction and strong conclusion
+- Naturally incorporate these keywords: {{ keywords }}
+- Do NOT include the title in the HTML (it will be set separately)
+- Do NOT wrap in <html>, <head>, or <body> tags — just the article content
+- Follow EVERY formatting and structural requirement from your system prompt style guide
+TPL;
+
+	/** Multi-step stage 3: polish (canonical name — ARCHITECTURE once said 'edit'). */
+	public const CONTENT_POLISH = <<<'TPL'
+Review and polish this blog post draft. Improve:
+1. Flow and readability
+2. SEO optimization (headings, keyword placement)
+3. Engagement (hooks, transitions, call-to-action)
+4. Accuracy and clarity
+5. Remove any filler or redundant sentences
+
+IMPORTANT: Preserve all bullet points, numbered lists, hyperlinks, and structural elements from the draft. Do NOT flatten lists into prose or remove links. Ensure every requirement from your system prompt style guide is satisfied in the final output.
+
+Return the polished HTML content only. Do not add commentary.
+
+DRAFT:
+{{ draft }}
+TPL;
+
+	/**
+	 * Analyzer system prompt. The *_block tokens carry their own trailing
+	 * separators when non-empty ('' when absent) so the rendered output is
+	 * byte-identical to the historical concatenation.
+	 */
+	public const ANALYSIS_SYSTEM = <<<'TPL'
+You are a content strategist analyzing social media discussions to find article ideas for a blog{{ niche_clause }}.
+
+IMPORTANT: You must identify exactly {{ target_count }} DISTINCT article ideas. Each idea must cover a substantially different topic — no two ideas should overlap in their main subject. Aim for diversity across these categories:
+1. QUESTIONS: Recurring questions people ask ("How do I...", "What is...", "Is it safe to...")
+2. COMPLAINTS: Pain points, frustrations, or problems people report
+3. COMPARISONS: Product/method comparisons people discuss ("X vs Y", "Which is better")
+4. NEWS: Recent developments, rule changes, or trends people are discussing
+5. GUIDES: How-to topics, best practices, or educational content people need
+
+Spread your {{ target_count }} ideas across multiple categories. Be specific — "peptide dosing for BPC-157" is better than "peptide information". Each idea should be narrow enough to be a single focused blog post.
+
+For each idea, provide:
+- type: 'question', 'complaint', 'comparison', 'news', or 'guide'
+- topic: A clear, specific, narrow topic description
+- summary: 1-2 sentence summary of why this topic matters
+- frequency: How many of the provided posts relate to this topic
+- relevance_score: 0.0 to 1.0 indicating how relevant and article-worthy this is
+- suggested_title: A compelling, unique blog post title
+- key_points: Array of 3-5 key points the article should cover
+- target_keywords: Array of SEO keywords for this topic
+
+{{ performance_block }}{{ recent_articles_block }}{{ instructions_block }}Respond with valid JSON containing exactly {{ target_count }} patterns:
+{"patterns": [{"type": "...", "topic": "...", "summary": "...", "frequency": N, "relevance_score": 0.X, "suggested_title": "...", "key_points": [...], "target_keywords": [...]}]}
+TPL;
+
+	/** Analyzer user prompt wrapping the source-data summary. */
+	public const ANALYSIS_USER = <<<'TPL'
+Here are the recent social media posts and comments to analyze. Find {{ target_count }} distinct, diverse article ideas from this data:
+
+{{ summary }}
+TPL;
+
+	/**
+	 * Registry definitions for the content + analysis keys.
+	 *
+	 * Each entry: body (the v1 template), model_option (the wp_option that
+	 * selects the model at call time — informational in Phase 1) and params
+	 * (the call-time LLM parameters, snapshotted for audit comparability).
+	 *
+	 * @return array<string, array{body: string, model_option: ?string, params: array<string, mixed>}>
+	 */
+	public static function defs(): array {
+		return array(
+			'content.system'      => array(
+				'body'         => self::CONTENT_SYSTEM,
+				'model_option' => 'prautoblogger_writing_model',
+				'params'       => array(),
+			),
+			'content.single_pass' => array(
+				'body'         => self::CONTENT_SINGLE_PASS,
+				'model_option' => 'prautoblogger_writing_model',
+				'params'       => array(
+					'temperature' => 0.7,
+					'max_tokens'  => 4000,
+				),
+			),
+			'content.outline'     => array(
+				'body'         => self::CONTENT_OUTLINE,
+				'model_option' => 'prautoblogger_writing_model',
+				'params'       => array(
+					'temperature' => 0.5,
+					'max_tokens'  => 1500,
+				),
+			),
+			'content.draft'       => array(
+				'body'         => self::CONTENT_DRAFT,
+				'model_option' => 'prautoblogger_writing_model',
+				'params'       => array(
+					'temperature' => 0.7,
+					'max_tokens'  => 4000,
+				),
+			),
+			'content.polish'      => array(
+				'body'         => self::CONTENT_POLISH,
+				'model_option' => 'prautoblogger_writing_model',
+				'params'       => array(
+					'temperature' => 0.4,
+					'max_tokens'  => 4000,
+				),
+			),
+			'analysis.system'     => array(
+				'body'         => self::ANALYSIS_SYSTEM,
+				'model_option' => 'prautoblogger_analysis_model',
+				'params'       => array(
+					'temperature' => 0.5,
+					'max_tokens'  => 8000,
+				),
+			),
+			'analysis.user'       => array(
+				'body'         => self::ANALYSIS_USER,
+				'model_option' => 'prautoblogger_analysis_model',
+				'params'       => array(),
+			),
+		);
+	}
+}

--- a/includes/core/class-prompt-registry-writer.php
+++ b/includes/core/class-prompt-registry-writer.php
@@ -1,0 +1,143 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * phpcs:ignore WordPress.Files.FileName.InvalidClassFileName -- class naming convention differs from WordPress standard
+ *
+ * Write side of the versioned prompt registry: create / activate / seed.
+ *
+ * What: Companion to PRAutoBlogger_Prompt_Registry (split for the 300-line
+ *       cap). Owns every mutation of `wp_prautoblogger_prompts` and
+ *       enforces the immutability rule: a stored body is NEVER updated —
+ *       a change is a new (prompt_key, version) row, and `activate()`
+ *       flips the single active flag per key. `seed_v1()` writes the
+ *       canonical v0.16.0 texts as version 1 (idempotent — keys that
+ *       already have rows keep their history). This is the API surface
+ *       the Phase-2 in-admin Prompts editor will call; Phase 1 ships no UI.
+ * Who triggers it: PRAutoBlogger_Activator (seed migration on db 1.2.0),
+ *       Phase-2 admin (create/activate), WP-CLI (future).
+ * Dependencies: WordPress $wpdb, PRAutoBlogger_Prompt_Registry (table name,
+ *       availability probe, defs, cache flush).
+ *
+ * @see core/class-prompt-registry.php — Read side (render, pins, fallback).
+ * @see class-activator.php            — Calls seed_v1() once, flag-gated.
+ */
+class PRAutoBlogger_Prompt_Registry_Writer {
+
+	/**
+	 * All versions of a key, newest first (Phase-2 list/diff support).
+	 *
+	 * @param string $key Registry key.
+	 * @return array<int, array<string, mixed>>
+	 */
+	public static function list_versions( string $key ): array {
+		if ( ! PRAutoBlogger_Prompt_Registry::is_available() ) {
+			return array();
+		}
+		global $wpdb;
+		$table = PRAutoBlogger_Prompt_Registry::table_name();
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results(
+			$wpdb->prepare( "SELECT * FROM {$table} WHERE prompt_key = %s ORDER BY version DESC", $key ),
+			ARRAY_A
+		);
+		return is_array( $rows ) ? $rows : array();
+	}
+
+	/**
+	 * Create a NEW immutable version of a key and (optionally) activate it.
+	 * Never mutates an existing row's body — that is the whole point.
+	 *
+	 * @param string                    $key      Registry key.
+	 * @param string                    $body     Template body.
+	 * @param string|null               $model    Optional model hint.
+	 * @param array<string, mixed>|null $params   Optional params snapshot.
+	 * @param string                    $author   Who created it (seed tag, login, agent).
+	 * @param bool                      $activate Flip active to this version (default true).
+	 * @return int New version number, or 0 on failure / table unavailable.
+	 */
+	public static function create_version( string $key, string $body, ?string $model, ?array $params, string $author, bool $activate = true ): int {
+		if ( ! PRAutoBlogger_Prompt_Registry::is_available() ) {
+			return 0;
+		}
+		global $wpdb;
+		$table = PRAutoBlogger_Prompt_Registry::table_name();
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$max  = (int) $wpdb->get_var(
+			$wpdb->prepare( "SELECT MAX(version) FROM {$table} WHERE prompt_key = %s", $key )
+		);
+		$next = $max + 1;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$ok = $wpdb->insert(
+			$table,
+			array(
+				'prompt_key'  => $key,
+				'version'     => $next,
+				'body'        => $body,
+				'model'       => $model,
+				'params_json' => null !== $params ? wp_json_encode( $params ) : null,
+				'author'      => $author,
+				'created_at'  => current_time( 'mysql' ),
+				'active'      => 0,
+			)
+		);
+		if ( false === $ok ) {
+			return 0;
+		}
+		if ( $activate ) {
+			self::activate( $key, $next );
+		}
+		return $next;
+	}
+
+	/**
+	 * Make one version the single active version of its key.
+	 *
+	 * @param string $key     Registry key.
+	 * @param int    $version Version to activate.
+	 * @return bool True when the version is now active.
+	 */
+	public static function activate( string $key, int $version ): bool {
+		if ( ! PRAutoBlogger_Prompt_Registry::is_available() ) {
+			return false;
+		}
+		global $wpdb;
+		$table = PRAutoBlogger_Prompt_Registry::table_name();
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->query( $wpdb->prepare( "UPDATE {$table} SET active = 0 WHERE prompt_key = %s", $key ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$updated = $wpdb->query(
+			$wpdb->prepare( "UPDATE {$table} SET active = 1 WHERE prompt_key = %s AND version = %d", $key, $version )
+		);
+		PRAutoBlogger_Prompt_Registry::flush_cache();
+		return 1 === (int) $updated;
+	}
+
+	/**
+	 * Seed every registry key with its canonical v1 body. Idempotent: keys
+	 * that already have rows are left untouched (their history is theirs).
+	 *
+	 * Side effects: up to one INSERT + two UPDATEs per missing key.
+	 *
+	 * @param string $author Audit tag for the seed rows (e.g. 'seed:v0.18.0').
+	 * @return int Number of keys seeded.
+	 */
+	public static function seed_v1( string $author = 'seed:v0.18.0' ): int {
+		if ( ! PRAutoBlogger_Prompt_Registry::is_available() ) {
+			return 0;
+		}
+		$seeded = 0;
+		foreach ( PRAutoBlogger_Prompt_Registry::defs() as $key => $def ) {
+			if ( ! empty( self::list_versions( $key ) ) ) {
+				continue;
+			}
+			$model   = null !== $def['model_option'] ? (string) get_option( $def['model_option'], '' ) : null;
+			$version = self::create_version( $key, $def['body'], '' !== (string) $model ? $model : null, $def['params'], $author, true );
+			if ( $version > 0 ) {
+				++$seeded;
+			}
+		}
+		PRAutoBlogger_Prompt_Registry::flush_cache();
+		return $seeded;
+	}
+}

--- a/includes/core/class-prompt-registry.php
+++ b/includes/core/class-prompt-registry.php
@@ -1,0 +1,214 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * phpcs:ignore WordPress.Files.FileName.InvalidClassFileName -- class naming convention differs from WordPress standard
+ *
+ * Versioned prompt registry — immutable versions, one active row per key.
+ *
+ * What: Read/write API over `wp_prautoblogger_prompts`. Rendering resolves
+ *       the ACTIVE body for a key and fills `{{ token }}` placeholders;
+ *       when the table is missing or has no row for the key (half-migrated
+ *       site, failed seed), it falls back to the canonical defaults the
+ *       seed itself uses — byte-identical output, no fatals (self-healing).
+ *       Versions are IMMUTABLE: there is no update path for a stored body;
+ *       changes create a new (prompt_key, version) row and flip `active`
+ *       (write side lives in PRAutoBlogger_Prompt_Registry_Writer).
+ *       Runs pin the active version of every key at start (stored on the
+ *       runs row) so generation_log rows can be stamped with the exact
+ *       prompt_version they rendered with. No admin UI in Phase 1 — the
+ *       list/activate/create API is what the Phase-2 Prompts screen needs.
+ * Who triggers it: Content_Prompts / Analysis_Prompts / Chief_Editor /
+ *       LLM_Research_Provider (render), Cost_Tracker (pins_for_run),
+ *       Activator (seed_v1), Cost_Tracker::set_run_id (pin_for_run).
+ * Dependencies: WordPress $wpdb, Prompt_Defaults(+Editorial), wp_json_encode.
+ *
+ * @see core/class-prompt-defaults.php           — Canonical v1 bodies (seed + fallback).
+ * @see core/class-prompt-defaults-editorial.php — Editor/research/image bodies.
+ * @see core/class-run-state.php                 — Owns the runs row the pins live on.
+ * @see ARCHITECTURE.md #21                      — Design rationale.
+ */
+class PRAutoBlogger_Prompt_Registry {
+
+	/** @var array<string, ?array<string, mixed>> Per-request active-row cache. */
+	private static array $active_cache = array();
+
+	/** @var array<string, array<string, int>> Per-request run-pins cache. */
+	private static array $pins_cache = array();
+
+	/** @var bool|null Per-request "table exists" probe result. */
+	private static ?bool $table_ok = null;
+
+	/** Fully-qualified prompts table name (shared with Prompt_Registry_Writer). */
+	public static function table_name(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'prautoblogger_prompts';
+	}
+
+	/**
+	 * Whether the prompts table exists and is queryable. Cached per request;
+	 * never throws — any failure reads as "not available" and every consumer
+	 * falls back to the in-code defaults.
+	 *
+	 * @return bool
+	 */
+	public static function is_available(): bool {
+		if ( null !== self::$table_ok ) {
+			return self::$table_ok;
+		}
+		global $wpdb;
+		if ( null === $wpdb ) {
+			return false; // Not cached: $wpdb may appear later in boot.
+		}
+		$table = self::table_name();
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$found          = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+		self::$table_ok = ( $found === $table );
+		return self::$table_ok;
+	}
+
+	/**
+	 * All registry definitions (content + analysis + editor + research + image).
+	 *
+	 * @return array<string, array{body: string, model_option: ?string, params: array<string, mixed>}>
+	 */
+	public static function defs(): array {
+		return array_merge(
+			PRAutoBlogger_Prompt_Defaults::defs(),
+			PRAutoBlogger_Prompt_Defaults_Editorial::defs()
+		);
+	}
+
+	/**
+	 * Canonical in-code default body for a key (the same text seeded as v1).
+	 *
+	 * @param string $key Registry key.
+	 * @return string|null Body template, or null for unknown keys.
+	 */
+	public static function default_body( string $key ): ?string {
+		$defs = self::defs();
+		return isset( $defs[ $key ] ) ? $defs[ $key ]['body'] : null;
+	}
+
+	/**
+	 * Active row for a key, or null when none / table unavailable.
+	 *
+	 * @param string $key Registry key.
+	 * @return array<string, mixed>|null Row with prompt_key, version, body, model, params_json, author, created_at, active.
+	 */
+	public static function get_active( string $key ): ?array {
+		if ( array_key_exists( $key, self::$active_cache ) ) {
+			return self::$active_cache[ $key ];
+		}
+		$row = null;
+		if ( self::is_available() ) {
+			global $wpdb;
+			$table = self::table_name();
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$row = $wpdb->get_row(
+				$wpdb->prepare(
+					"SELECT * FROM {$table} WHERE prompt_key = %s AND active = 1 ORDER BY version DESC LIMIT 1",
+					$key
+				),
+				ARRAY_A
+			);
+			$row = is_array( $row ) ? $row : null;
+		}
+		self::$active_cache[ $key ] = $row;
+		return $row;
+	}
+
+	/**
+	 * Render a prompt: active body for the key (fallback: canonical default),
+	 * with `{{ token }}` placeholders substituted.
+	 *
+	 * @param string                $key    Registry key (e.g. 'content.single_pass').
+	 * @param array<string, string> $tokens Token name => replacement value.
+	 * @return string Rendered prompt ('' only if the key is unknown AND absent).
+	 */
+	public static function render( string $key, array $tokens = array() ): string {
+		$active = self::get_active( $key );
+		$body   = null !== $active ? (string) $active['body'] : (string) self::default_body( $key );
+		return self::fill( $body, $tokens );
+	}
+
+	/**
+	 * Substitute `{{ token }}` placeholders in a template body.
+	 *
+	 * @param string                $body   Template body.
+	 * @param array<string, string> $tokens Token name => replacement value.
+	 * @return string
+	 */
+	public static function fill( string $body, array $tokens ): string {
+		foreach ( $tokens as $name => $value ) {
+			$body = str_replace( '{{ ' . $name . ' }}', (string) $value, $body );
+		}
+		return $body;
+	}
+
+	/**
+	 * Map of prompt_key => active version for every key present in the table.
+	 *
+	 * @return array<string, int>
+	 */
+	public static function active_versions(): array {
+		if ( ! self::is_available() ) {
+			return array();
+		}
+		global $wpdb;
+		$table = self::table_name();
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results( "SELECT prompt_key, version FROM {$table} WHERE active = 1", ARRAY_A );
+		$map  = array();
+		foreach ( ( is_array( $rows ) ? $rows : array() ) as $row ) {
+			$map[ (string) $row['prompt_key'] ] = (int) $row['version'];
+		}
+		return $map;
+	}
+
+	/**
+	 * Pin the current active versions onto a run's row (once, at run start).
+	 * No-ops when the runs row already carries pins (resume keeps the
+	 * versions the run started with) or when tables are unavailable.
+	 *
+	 * @param string $run_id Pipeline run UUID.
+	 * @return void
+	 */
+	public static function pin_for_run( string $run_id ): void {
+		if ( '' === $run_id || ! self::is_available() ) {
+			return;
+		}
+		$pins = self::active_versions();
+		if ( empty( $pins ) ) {
+			return;
+		}
+		PRAutoBlogger_Run_State::set_pins_if_absent( $run_id, $pins );
+		unset( self::$pins_cache[ $run_id ] );
+	}
+
+	/**
+	 * The pinned prompt versions for a run (cached per request). Empty when
+	 * the run has no pins (pre-1.2.0 rows, standalone calls, missing table).
+	 *
+	 * @param string|null $run_id Pipeline run UUID, or null.
+	 * @return array<string, int>
+	 */
+	public static function pins_for_run( ?string $run_id ): array {
+		if ( null === $run_id || '' === $run_id ) {
+			return array();
+		}
+		if ( isset( self::$pins_cache[ $run_id ] ) ) {
+			return self::$pins_cache[ $run_id ];
+		}
+		$pins                          = PRAutoBlogger_Run_State::get_pins( $run_id );
+		self::$pins_cache[ $run_id ] = $pins;
+		return $pins;
+	}
+
+	/** Reset per-request caches (tests). */
+	public static function flush_cache(): void {
+		self::$active_cache = array();
+		self::$pins_cache   = array();
+		self::$table_ok     = null;
+	}
+}

--- a/includes/core/class-publisher.php
+++ b/includes/core/class-publisher.php
@@ -82,6 +82,22 @@ class PRAutoBlogger_Publisher {
 		?string $run_id = null,
 		?PRAutoBlogger_Cost_Tracker $cost_tracker = null
 	): int {
+		// v0.18.0 idempotency: post creation is keyed by run + idea
+		// (check-before-insert) so a retried/resumed run cannot create a
+		// duplicate post. One run_id spans all N articles of a batch, so
+		// the idea hash disambiguates within the run.
+		$idea_hash = PRAutoBlogger_Run_Stage_State::idea_hash( $idea );
+		if ( null !== $run_id && '' !== $run_id ) {
+			$existing_id = $this->find_existing_post( $run_id, $idea_hash );
+			if ( $existing_id > 0 ) {
+				PRAutoBlogger_Logger::instance()->info(
+					sprintf( 'Post for run %s / idea %s already exists (ID=%d) — skipping duplicate insert.', $run_id, $idea_hash, $existing_id ),
+					'publisher'
+				);
+				return $existing_id;
+			}
+		}
+
 		// Clean LLM artifacts, then inject peptide hyperlinks deterministically
 		// before the content enters WordPress. Peptide linker no-ops gracefully
 		// if PR Core is not active.
@@ -94,7 +110,7 @@ class PRAutoBlogger_Publisher {
 			'post_status'  => $post_status,
 			'post_type'    => 'post',
 			'post_author'  => PRAutoBlogger_Post_Assembler::get_default_author_id(),
-			'meta_input'   => $this->build_meta( $idea, $review, $run_id ),
+			'meta_input'   => $this->build_meta( $idea, $review, $run_id, $idea_hash ),
 		);
 
 		/** @see class-prautoblogger.php — listeners registered in main loader. */
@@ -140,7 +156,8 @@ class PRAutoBlogger_Publisher {
 	private function build_meta(
 		PRAutoBlogger_Article_Idea $idea,
 		PRAutoBlogger_Editorial_Review $review,
-		?string $run_id = null
+		?string $run_id = null,
+		string $idea_hash = ''
 	): array {
 		$meta = array(
 			'_prautoblogger_generated'       => '1',
@@ -160,6 +177,42 @@ class PRAutoBlogger_Publisher {
 		if ( null !== $run_id && '' !== $run_id ) {
 			$meta['_prautoblogger_run_id'] = $run_id;
 		}
+		if ( '' !== $idea_hash ) {
+			$meta['_prautoblogger_idea_hash'] = $idea_hash;
+		}
 		return $meta;
+	}
+
+	/**
+	 * Find a post already created for this (run, idea) pair.
+	 *
+	 * Direct postmeta self-join (any post_status, including trash) — the
+	 * idempotency check must see drafts and pending posts too.
+	 *
+	 * @param string $run_id    Pipeline run UUID.
+	 * @param string $idea_hash Idea hash from Run_Stage_State::idea_hash().
+	 * @return int Existing post ID, or 0 when none.
+	 */
+	private function find_existing_post( string $run_id, string $idea_hash ): int {
+		global $wpdb;
+		if ( null === $wpdb ) {
+			return 0;
+		}
+		$postmeta = $wpdb->prefix . 'postmeta';
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$post_id = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT pm_run.post_id FROM {$postmeta} pm_run
+				INNER JOIN {$postmeta} pm_hash
+					ON pm_hash.post_id = pm_run.post_id
+					AND pm_hash.meta_key = '_prautoblogger_idea_hash'
+					AND pm_hash.meta_value = %s
+				WHERE pm_run.meta_key = '_prautoblogger_run_id' AND pm_run.meta_value = %s
+				LIMIT 1",
+				$idea_hash,
+				$run_id
+			)
+		);
+		return null !== $post_id ? (int) $post_id : 0;
 	}
 }

--- a/includes/core/class-run-context.php
+++ b/includes/core/class-run-context.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * phpcs:ignore WordPress.Files.FileName.InvalidClassFileName -- class naming convention differs from WordPress standard
+ *
+ * Per-PHP-process holder for the active pipeline run id.
+ *
+ * What: A process-scoped static slot recording which run this PHP request
+ *       is executing, set whenever Cost_Tracker::set_run_id() is called
+ *       (daily cron, manual generation, queued-article jobs, ideas
+ *       browser). It lets components that are constructed without a run
+ *       reference — the OpenRouter provider (cost-governor guard) and
+ *       standalone Cost_Tracker instances (e.g. the image prompt
+ *       rewriter's) — resolve the surrounding run for reservation and
+ *       prompt-version stamping without threading a parameter through
+ *       every constructor. Mirrors the Opik_Trace_Context precedent.
+ * Who triggers it: PRAutoBlogger_Cost_Tracker::set_run_id() (set);
+ *       Cost_Governor + Cost_Tracker (read).
+ * Dependencies: none.
+ *
+ * @see core/class-cost-tracker.php  — Sets the context on set_run_id().
+ * @see core/class-cost-governor.php — Reads it to guard LLM calls.
+ */
+class PRAutoBlogger_Run_Context {
+
+	/** @var string|null Active run id for this PHP process, or null. */
+	private static ?string $run_id = null;
+
+	/**
+	 * Record the active run id for this process.
+	 *
+	 * @param string $run_id Pipeline run UUID.
+	 * @return void
+	 */
+	public static function set_run_id( string $run_id ): void {
+		if ( '' !== $run_id ) {
+			self::$run_id = $run_id;
+		}
+	}
+
+	/**
+	 * The active run id for this process, or null outside any run.
+	 *
+	 * @return string|null
+	 */
+	public static function current_run_id(): ?string {
+		return self::$run_id;
+	}
+
+	/**
+	 * Clear the context (tests / end of run).
+	 *
+	 * @return void
+	 */
+	public static function clear(): void {
+		self::$run_id = null;
+	}
+}

--- a/includes/core/class-run-reaper.php
+++ b/includes/core/class-run-reaper.php
@@ -1,0 +1,270 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * phpcs:ignore WordPress.Files.FileName.InvalidClassFileName -- class naming convention differs from WordPress standard
+ *
+ * Daily sweep for stuck runs + audit-payload retention (extends #19).
+ *
+ * What: Rides the EXISTING `prautoblogger_reap_orphan_research_rows` cron
+ *       (no new schedule) alongside the v0.8.1 Research_Reaper. Three jobs:
+ *       1. Stage sweep — run_stages rows stuck `running` longer than
+ *          2× the stage's expected wall-clock are marked `failed`
+ *          (Hostinger kills PHP at ~120s; a stage "running" for 10+
+ *          minutes is dead, its process gone).
+ *       2. Run sweep — runs rows still open (pending/running) with no
+ *          ledger/state activity for 2× the expected run wall-clock are
+ *          marked `failed` and their non-done stages reaped to `failed`;
+ *          such runs render as "incomplete" via incomplete_runs().
+ *       3. Retention — `request_json` on generation_log and stage output
+ *          payloads (`meta_json` on run_stages) are NULLed after R days;
+ *          R comes from the `prautoblogger_request_json_retention_days`
+ *          SETTING (default constant 14; 0 = keep forever) — never a
+ *          literal at the point of use.
+ * Who triggers it: WP-Cron `prautoblogger_reap_orphan_research_rows`
+ *       (daily 03:15, registered in class-prautoblogger.php).
+ * Dependencies: Run_State, Run_Stage_State, WordPress $wpdb, Logger.
+ *
+ * @see core/class-research-reaper.php — The #19 orphan-cost reaper (same cron).
+ * @see core/class-run-state.php       — Run rows swept here.
+ * @see ARCHITECTURE.md #21            — Design rationale.
+ */
+class PRAutoBlogger_Run_Reaper {
+
+	/**
+	 * Expected per-stage wall-clock seconds (sweep threshold = 2×). An
+	 * engineering constant (like Research_Reaper::GRACE_WINDOW_SECONDS),
+	 * overridable per stage via the
+	 * `prautoblogger_filter_stage_expected_seconds` filter.
+	 */
+	private const EXPECTED_STAGE_SECONDS = 300;
+
+	/**
+	 * Expected whole-run wall-clock seconds (collect + analyze + up to 10
+	 * chained articles ≈ 30 min worst case). Sweep threshold = 2×.
+	 * Overridable via `prautoblogger_filter_expected_run_seconds`.
+	 */
+	private const EXPECTED_RUN_SECONDS = 1800;
+
+	/**
+	 * Cron action handler — entrypoint. Pure delegate, never throws.
+	 *
+	 * @return void
+	 */
+	public static function on_cron(): void {
+		self::reap();
+	}
+
+	/**
+	 * Run all three sweeps. Returns a summary (cron path ignores it).
+	 *
+	 * Side effects: UPDATEs on run_stages / runs / generation_log; INFO
+	 * log lines for swept runs.
+	 *
+	 * @return array{stages_failed: int, runs_failed: int, payloads_pruned: int}
+	 */
+	public static function reap(): array {
+		$stats = array(
+			'stages_failed'   => 0,
+			'runs_failed'     => 0,
+			'payloads_pruned' => 0,
+		);
+
+		try {
+			$stats['stages_failed']   = self::sweep_stuck_stages();
+			$stats['runs_failed']     = self::sweep_stuck_runs();
+			$stats['payloads_pruned'] = self::prune_payloads();
+		} catch ( \Throwable $e ) {
+			PRAutoBlogger_Logger::instance()->warning(
+				'Run reaper encountered an error: ' . $e->getMessage(),
+				'run-reaper'
+			);
+		}
+
+		return $stats;
+	}
+
+	/**
+	 * Runs that died mid-pipeline, for audit surfaces: failed/halted runs
+	 * that still have non-done stage rows ("incomplete").
+	 *
+	 * @param int $limit Max rows (default 20).
+	 * @return array<int, array<string, mixed>>
+	 */
+	public static function incomplete_runs( int $limit = 20 ): array {
+		if ( ! PRAutoBlogger_Run_State::is_available() || ! PRAutoBlogger_Run_Stage_State::is_available() ) {
+			return array();
+		}
+		global $wpdb;
+		$runs   = PRAutoBlogger_Run_State::table_name();
+		$stages = PRAutoBlogger_Run_Stage_State::table_name();
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT r.* FROM {$runs} r
+				WHERE r.status IN ('failed','halted')
+					AND EXISTS (SELECT 1 FROM {$stages} s WHERE s.run_id = r.run_id AND s.status != 'done')
+				ORDER BY r.updated_at DESC LIMIT %d",
+				$limit
+			),
+			ARRAY_A
+		);
+		return is_array( $rows ) ? $rows : array();
+	}
+
+	/**
+	 * Stage sweep: `running` rows older than 2× expected stage wall-clock
+	 * become `failed`.
+	 *
+	 * @return int Rows swept.
+	 */
+	private static function sweep_stuck_stages(): int {
+		if ( ! PRAutoBlogger_Run_Stage_State::is_available() ) {
+			return 0;
+		}
+		global $wpdb;
+		$table = PRAutoBlogger_Run_Stage_State::table_name();
+
+		/**
+		 * Filter the expected per-stage wall-clock seconds used by the
+		 * stuck-stage sweep (threshold is 2× this value).
+		 *
+		 * @param int $seconds Expected seconds (default 300).
+		 */
+		$expected = (int) apply_filters( 'prautoblogger_filter_stage_expected_seconds', self::EXPECTED_STAGE_SECONDS );
+		$cutoff   = gmdate( 'Y-m-d H:i:s', time() - ( 2 * $expected ) );
+		$now      = current_time( 'mysql' );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$swept = $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE {$table} SET status = 'failed', updated_at = %s, finished_at = %s
+				WHERE status = 'running' AND updated_at < %s",
+				$now,
+				$now,
+				$cutoff
+			)
+		);
+		return is_numeric( $swept ) ? (int) $swept : 0;
+	}
+
+	/**
+	 * Run sweep: open runs with no activity for 2× expected run wall-clock
+	 * are marked `failed`; their pending/running stages are reaped.
+	 *
+	 * @return int Runs swept.
+	 */
+	private static function sweep_stuck_runs(): int {
+		if ( ! PRAutoBlogger_Run_State::is_available() ) {
+			return 0;
+		}
+		global $wpdb;
+		$runs = PRAutoBlogger_Run_State::table_name();
+
+		/**
+		 * Filter the expected whole-run wall-clock seconds used by the
+		 * stuck-run sweep (threshold is 2× this value).
+		 *
+		 * @param int $seconds Expected seconds (default 1800).
+		 */
+		$expected = (int) apply_filters( 'prautoblogger_filter_expected_run_seconds', self::EXPECTED_RUN_SECONDS );
+		$cutoff   = gmdate( 'Y-m-d H:i:s', time() - ( 2 * $expected ) );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$stuck = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT run_id FROM {$runs} WHERE status IN ('pending','running') AND updated_at < %s",
+				$cutoff
+			)
+		);
+		if ( ! is_array( $stuck ) || empty( $stuck ) ) {
+			return 0;
+		}
+
+		$swept = 0;
+		foreach ( $stuck as $run_id ) {
+			$run_id = (string) $run_id;
+			if ( ! PRAutoBlogger_Run_State::mark_status( $run_id, 'failed' ) ) {
+				continue;
+			}
+			self::reap_open_stages( $run_id );
+			PRAutoBlogger_Logger::instance()->info(
+				sprintf( 'Run %s stuck past 2x expected wall-clock — marked failed (renders as incomplete).', $run_id ),
+				'run-reaper'
+			);
+			++$swept;
+		}
+		return $swept;
+	}
+
+	/**
+	 * Mark a failed run's pending/running stage rows as failed.
+	 *
+	 * @param string $run_id Run UUID.
+	 * @return void
+	 */
+	private static function reap_open_stages( string $run_id ): void {
+		if ( ! PRAutoBlogger_Run_Stage_State::is_available() ) {
+			return;
+		}
+		global $wpdb;
+		$table = PRAutoBlogger_Run_Stage_State::table_name();
+		$now   = current_time( 'mysql' );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$wpdb->query(
+			$wpdb->prepare(
+				"UPDATE {$table} SET status = 'failed', updated_at = %s, finished_at = %s
+				WHERE run_id = %s AND status IN ('pending','running')",
+				$now,
+				$now,
+				$run_id
+			)
+		);
+	}
+
+	/**
+	 * Retention: NULL heavy payloads older than R days. R is read from the
+	 * `prautoblogger_request_json_retention_days` setting at every call
+	 * (default = PRAUTOBLOGGER_DEFAULT_REQUEST_JSON_RETENTION_DAYS;
+	 * 0 or negative = keep forever).
+	 *
+	 * @return int Rows pruned (both tables combined).
+	 */
+	private static function prune_payloads(): int {
+		$days = (int) get_option(
+			'prautoblogger_request_json_retention_days',
+			PRAUTOBLOGGER_DEFAULT_REQUEST_JSON_RETENTION_DAYS
+		);
+		if ( $days <= 0 ) {
+			return 0;
+		}
+
+		global $wpdb;
+		$cutoff = gmdate( 'Y-m-d H:i:s', time() - ( $days * DAY_IN_SECONDS ) );
+		$pruned = 0;
+
+		$gen_log = $wpdb->prefix . 'prautoblogger_generation_log';
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE {$gen_log} SET request_json = NULL WHERE request_json IS NOT NULL AND created_at < %s",
+				$cutoff
+			)
+		);
+		$pruned += is_numeric( $result ) ? (int) $result : 0;
+
+		if ( PRAutoBlogger_Run_Stage_State::is_available() ) {
+			$stages = PRAutoBlogger_Run_Stage_State::table_name();
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+			$result = $wpdb->query(
+				$wpdb->prepare(
+					"UPDATE {$stages} SET meta_json = NULL WHERE meta_json IS NOT NULL AND updated_at < %s",
+					$cutoff
+				)
+			);
+			$pruned += is_numeric( $result ) ? (int) $result : 0;
+		}
+
+		return $pruned;
+	}
+}

--- a/includes/core/class-run-stage-state.php
+++ b/includes/core/class-run-stage-state.php
@@ -1,0 +1,293 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * phpcs:ignore WordPress.Files.FileName.InvalidClassFileName -- class naming convention differs from WordPress standard
+ *
+ * Per-run per-stage state machine over `wp_prautoblogger_run_stages`.
+ *
+ * What: One row per (run_id, stage, agent_role, item_key) holding
+ *       pending|running|done|failed|halted plus the stage's output
+ *       snapshot (meta_json). This is what makes resume idempotent on the
+ *       chained-cron architecture: a `done` stage is NEVER re-run or
+ *       re-charged — re-entry reuses its stored output; `done` is sticky
+ *       (an upsert cannot demote it). agent_role is the Phase-2 fan-out
+ *       dimension (quorum members; the quorum logic itself is Phase 2);
+ *       item_key scopes article-level stages because one run_id spans all
+ *       N articles of a batch run ('' for run-level stages). Self-healing:
+ *       a missing table degrades every method to a no-op/false.
+ * Who triggers it: Pipeline_Runner (run-level research/analysis),
+ *       Article_Worker (per-article generate/review/publish),
+ *       Content_Generator (per-LLM-stage outline/draft/polish),
+ *       Run_Reaper (stuck-stage sweep + payload pruning).
+ * Dependencies: WordPress $wpdb, wp_json_encode.
+ *
+ * @see core/class-run-state.php   — Run-level lifecycle + ledger row.
+ * @see core/class-run-reaper.php  — Sweeps stages stuck in 'running'.
+ * @see ARCHITECTURE.md #21        — Idempotency-key design.
+ */
+class PRAutoBlogger_Run_Stage_State {
+
+	/** @var bool|null Per-request "run_stages table exists" probe result. */
+	private static ?bool $table_ok = null;
+
+	/** Fully-qualified run_stages table name. */
+	public static function table_name(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'prautoblogger_run_stages';
+	}
+
+	/**
+	 * Whether the run_stages table exists and is queryable. Cached per
+	 * request; never throws.
+	 *
+	 * @return bool
+	 */
+	public static function is_available(): bool {
+		if ( null !== self::$table_ok ) {
+			return self::$table_ok;
+		}
+		global $wpdb;
+		if ( null === $wpdb ) {
+			return false; // Not cached: $wpdb may appear later in boot.
+		}
+		$table = self::table_name();
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$found          = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+		self::$table_ok = ( $found === $table );
+		return self::$table_ok;
+	}
+
+	/**
+	 * Stable hash identifying one article idea within a run (post-creation
+	 * idempotency + stage item scoping both key off this).
+	 *
+	 * @param PRAutoBlogger_Article_Idea $idea The idea.
+	 * @return string 16-hex-char hash.
+	 */
+	public static function idea_hash( PRAutoBlogger_Article_Idea $idea ): string {
+		return substr( md5( $idea->get_suggested_title() . '|' . $idea->get_topic() ), 0, 16 );
+	}
+
+	/**
+	 * Stage item_key for an article idea ('' is reserved for run-level stages).
+	 *
+	 * @param PRAutoBlogger_Article_Idea $idea The idea.
+	 * @return string e.g. 'idea:1a2b3c4d5e6f7a8b'.
+	 */
+	public static function item_key_for_idea( PRAutoBlogger_Article_Idea $idea ): string {
+		return 'idea:' . self::idea_hash( $idea );
+	}
+
+	/**
+	 * Mark a stage as entered (running). Upsert: first entry inserts the
+	 * row; re-entry bumps `attempt` — but a `done` stage is sticky and is
+	 * neither demoted nor re-counted.
+	 *
+	 * Side effects: one INSERT … ON DUPLICATE KEY UPDATE.
+	 *
+	 * @param string $run_id     Run UUID.
+	 * @param string $stage      Stage name (see Stage_Display_Map).
+	 * @param string $agent_role Fan-out dimension ('' default in Phase 1).
+	 * @param string $item_key   Article scope ('' for run-level stages).
+	 * @return void
+	 */
+	public static function start( string $run_id, string $stage, string $agent_role = '', string $item_key = '' ): void {
+		if ( '' === $run_id || ! self::is_available() ) {
+			return;
+		}
+		global $wpdb;
+		$table = self::table_name();
+		$now   = current_time( 'mysql' );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$wpdb->query(
+			$wpdb->prepare(
+				"INSERT INTO {$table}
+				(run_id, stage, agent_role, item_key, status, attempt, started_at, updated_at)
+				VALUES (%s, %s, %s, %s, 'running', 1, %s, %s)
+				ON DUPLICATE KEY UPDATE
+					attempt = IF(status = 'done', attempt, attempt + 1),
+					status = IF(status = 'done', 'done', 'running'),
+					updated_at = VALUES(updated_at)",
+				$run_id,
+				$stage,
+				$agent_role,
+				$item_key,
+				$now,
+				$now
+			)
+		);
+	}
+
+	/**
+	 * Mark a stage done, persisting its output for resume-without-recharge.
+	 *
+	 * Side effects: one INSERT … ON DUPLICATE KEY UPDATE.
+	 *
+	 * @param string      $run_id     Run UUID.
+	 * @param string      $stage      Stage name.
+	 * @param string      $agent_role Fan-out dimension.
+	 * @param string      $item_key   Article scope.
+	 * @param string|null $output     Stage output to snapshot (pruned after R days).
+	 * @param float       $cost_usd   Cost attributed to the stage.
+	 * @return void
+	 */
+	public static function done( string $run_id, string $stage, string $agent_role = '', string $item_key = '', ?string $output = null, float $cost_usd = 0.0 ): void {
+		if ( '' === $run_id || ! self::is_available() ) {
+			return;
+		}
+		global $wpdb;
+		$table = self::table_name();
+		$now   = current_time( 'mysql' );
+		$meta  = null !== $output ? wp_json_encode( array( 'output' => $output ) ) : null;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$wpdb->query(
+			$wpdb->prepare(
+				"INSERT INTO {$table}
+				(run_id, stage, agent_role, item_key, status, attempt, cost_usd, meta_json, started_at, updated_at, finished_at)
+				VALUES (%s, %s, %s, %s, 'done', 1, %f, %s, %s, %s, %s)
+				ON DUPLICATE KEY UPDATE
+					status = 'done',
+					cost_usd = VALUES(cost_usd),
+					meta_json = VALUES(meta_json),
+					updated_at = VALUES(updated_at),
+					finished_at = VALUES(finished_at)",
+				$run_id,
+				$stage,
+				$agent_role,
+				$item_key,
+				$cost_usd,
+				$meta,
+				$now,
+				$now,
+				$now
+			)
+		);
+	}
+
+	/**
+	 * Mark a stage failed (does not demote a `done` stage).
+	 *
+	 * @param string $run_id     Run UUID.
+	 * @param string $stage      Stage name.
+	 * @param string $agent_role Fan-out dimension.
+	 * @param string $item_key   Article scope.
+	 * @return void
+	 */
+	public static function fail( string $run_id, string $stage, string $agent_role = '', string $item_key = '' ): void {
+		if ( '' === $run_id || ! self::is_available() ) {
+			return;
+		}
+		global $wpdb;
+		$table = self::table_name();
+		$now   = current_time( 'mysql' );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$wpdb->query(
+			$wpdb->prepare(
+				"UPDATE {$table} SET status = 'failed', updated_at = %s, finished_at = %s
+				WHERE run_id = %s AND stage = %s AND agent_role = %s AND item_key = %s AND status != 'done'",
+				$now,
+				$now,
+				$run_id,
+				$stage,
+				$agent_role,
+				$item_key
+			)
+		);
+	}
+
+	/**
+	 * Fetch one stage row.
+	 *
+	 * @param string $run_id     Run UUID.
+	 * @param string $stage      Stage name.
+	 * @param string $agent_role Fan-out dimension.
+	 * @param string $item_key   Article scope.
+	 * @return array<string, mixed>|null Row or null.
+	 */
+	public static function get( string $run_id, string $stage, string $agent_role = '', string $item_key = '' ): ?array {
+		if ( '' === $run_id || ! self::is_available() ) {
+			return null;
+		}
+		global $wpdb;
+		$table = self::table_name();
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT * FROM {$table} WHERE run_id = %s AND stage = %s AND agent_role = %s AND item_key = %s",
+				$run_id,
+				$stage,
+				$agent_role,
+				$item_key
+			),
+			ARRAY_A
+		);
+		return is_array( $row ) ? $row : null;
+	}
+
+	/**
+	 * Whether a stage already completed (resume entry-point check).
+	 *
+	 * @param string $run_id     Run UUID.
+	 * @param string $stage      Stage name.
+	 * @param string $agent_role Fan-out dimension.
+	 * @param string $item_key   Article scope.
+	 * @return bool
+	 */
+	public static function is_done( string $run_id, string $stage, string $agent_role = '', string $item_key = '' ): bool {
+		$row = self::get( $run_id, $stage, $agent_role, $item_key );
+		return null !== $row && 'done' === $row['status'];
+	}
+
+	/**
+	 * A done stage's stored output (null when absent, not done, or pruned).
+	 *
+	 * @param string $run_id     Run UUID.
+	 * @param string $stage      Stage name.
+	 * @param string $agent_role Fan-out dimension.
+	 * @param string $item_key   Article scope.
+	 * @return string|null
+	 */
+	public static function get_output( string $run_id, string $stage, string $agent_role = '', string $item_key = '' ): ?string {
+		$row = self::get( $run_id, $stage, $agent_role, $item_key );
+		if ( null === $row || 'done' !== $row['status'] || empty( $row['meta_json'] ) ) {
+			return null;
+		}
+		$meta = json_decode( (string) $row['meta_json'], true );
+		return is_array( $meta ) && isset( $meta['output'] ) ? (string) $meta['output'] : null;
+	}
+
+	/**
+	 * Fail every still-open (pending/running) stage of one item — used by
+	 * the worker's catch-all so a crashed article leaves no stage stuck
+	 * in 'running' until the reaper. Done stages are untouched.
+	 *
+	 * @param string $run_id   Run UUID.
+	 * @param string $item_key Stage item key ('' = run-level stages).
+	 * @return void
+	 */
+	public static function fail_open_for_item( string $run_id, string $item_key ): void {
+		if ( '' === $run_id || ! self::is_available() ) {
+			return;
+		}
+		global $wpdb;
+		$table = self::table_name();
+		$now   = current_time( 'mysql' );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$wpdb->query(
+			$wpdb->prepare(
+				"UPDATE {$table} SET status = 'failed', updated_at = %s, finished_at = %s
+				WHERE run_id = %s AND item_key = %s AND status IN ('pending','running')",
+				$now,
+				$now,
+				$run_id,
+				$item_key
+			)
+		);
+	}
+
+	/** Reset per-request caches (tests). */
+	public static function flush_cache(): void {
+		self::$table_ok = null;
+	}
+}

--- a/includes/core/class-run-state.php
+++ b/includes/core/class-run-state.php
@@ -1,0 +1,259 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * phpcs:ignore WordPress.Files.FileName.InvalidClassFileName -- class naming convention differs from WordPress standard
+ *
+ * Run-level state: the `wp_prautoblogger_runs` ledger + lifecycle row.
+ *
+ * What: One row per pipeline run (keyed by run_id UUID) carrying the run
+ *       status (pending|running|done|failed|halted), the per-run cost
+ *       ledger the Cost_Governor reserves against (ceiling / reserved /
+ *       settled / overage), and the prompt versions pinned at run start.
+ *       Every method is self-healing: a missing table (half-migrated
+ *       site) degrades to no-ops/empty reads, never a fatal. Final states
+ *       are sticky — a halted or failed run cannot be flipped back to
+ *       running by a late writer. Per-stage state lives in
+ *       PRAutoBlogger_Run_Stage_State (run_stages table).
+ * Who triggers it: Cost_Tracker::set_run_id() (ensure_run + pinning),
+ *       Cost_Governor (ledger + halt), Run_Reaper (stuck-run sweep),
+ *       Review Queue (halted-run surfacing), Pipeline_Runner (completion).
+ * Dependencies: WordPress $wpdb, get_option (ceiling setting), wp_json_encode.
+ *
+ * @see core/class-cost-governor.php       — Reserves against this row atomically.
+ * @see core/class-prompt-registry.php     — Reads/writes pins via this class.
+ * @see core/class-run-stage-state.php     — Per-stage rows (commit 4).
+ * @see ARCHITECTURE.md #21                — Design rationale.
+ */
+class PRAutoBlogger_Run_State {
+
+	/** @var bool|null Per-request "runs table exists" probe result. */
+	private static ?bool $table_ok = null;
+
+	/** Fully-qualified runs table name (shared with Cost_Governor). */
+	public static function table_name(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'prautoblogger_runs';
+	}
+
+	/**
+	 * Whether the runs table exists and is queryable. Cached per request;
+	 * never throws.
+	 *
+	 * @return bool
+	 */
+	public static function is_available(): bool {
+		if ( null !== self::$table_ok ) {
+			return self::$table_ok;
+		}
+		global $wpdb;
+		if ( null === $wpdb ) {
+			return false; // Not cached: $wpdb may appear later in boot.
+		}
+		$table = self::table_name();
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$found          = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+		self::$table_ok = ( $found === $table );
+		return self::$table_ok;
+	}
+
+	/**
+	 * The per-run cost ceiling, read from the SETTING at call time
+	 * (never a literal at the point of use). 0 disables the per-run guard.
+	 *
+	 * @return float Ceiling in USD.
+	 */
+	public static function ceiling_setting(): float {
+		return (float) get_option( 'prautoblogger_per_run_cost_ceiling_usd', PRAUTOBLOGGER_DEFAULT_RUN_CEILING_USD );
+	}
+
+	/**
+	 * Create the run row if it does not exist (INSERT IGNORE — concurrent
+	 * callers cannot double-create). Snapshots the ceiling setting at run
+	 * start so a mid-run settings change cannot move the goalposts.
+	 *
+	 * Side effects: one INSERT IGNORE.
+	 *
+	 * @param string $run_id Pipeline run UUID.
+	 * @return void
+	 */
+	public static function ensure_run( string $run_id ): void {
+		if ( '' === $run_id || ! self::is_available() ) {
+			return;
+		}
+		global $wpdb;
+		$table = self::table_name();
+		$now   = current_time( 'mysql' );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$wpdb->query(
+			$wpdb->prepare(
+				"INSERT IGNORE INTO {$table}
+				(run_id, status, ceiling_usd, reserved_usd, settled_usd, overage_usd, started_at, updated_at)
+				VALUES (%s, 'running', %f, 0, 0, 0, %s, %s)",
+				$run_id,
+				self::ceiling_setting(),
+				$now,
+				$now
+			)
+		);
+	}
+
+	/**
+	 * Fetch a run row.
+	 *
+	 * @param string $run_id Pipeline run UUID.
+	 * @return array<string, mixed>|null Row, or null when absent/unavailable.
+	 */
+	public static function get_run( string $run_id ): ?array {
+		if ( '' === $run_id || ! self::is_available() ) {
+			return null;
+		}
+		global $wpdb;
+		$table = self::table_name();
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$row = $wpdb->get_row(
+			$wpdb->prepare( "SELECT * FROM {$table} WHERE run_id = %s", $run_id ),
+			ARRAY_A
+		);
+		return is_array( $row ) ? $row : null;
+	}
+
+	/**
+	 * Current run status, or null when the run has no row.
+	 *
+	 * @param string $run_id Pipeline run UUID.
+	 * @return string|null pending|running|done|failed|halted, or null.
+	 */
+	public static function get_status( string $run_id ): ?string {
+		$run = self::get_run( $run_id );
+		return null !== $run ? (string) $run['status'] : null;
+	}
+
+	/**
+	 * Store the pinned prompt versions — only if the run has none yet, so
+	 * a resumed run keeps the versions it started with.
+	 *
+	 * @param string             $run_id Pipeline run UUID.
+	 * @param array<string, int> $pins   prompt_key => version map.
+	 * @return void
+	 */
+	public static function set_pins_if_absent( string $run_id, array $pins ): void {
+		if ( '' === $run_id || empty( $pins ) || ! self::is_available() ) {
+			return;
+		}
+		self::ensure_run( $run_id );
+		global $wpdb;
+		$table = self::table_name();
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$wpdb->query(
+			$wpdb->prepare(
+				"UPDATE {$table} SET pinned_prompts_json = %s, updated_at = %s
+				WHERE run_id = %s AND (pinned_prompts_json IS NULL OR pinned_prompts_json = '')",
+				wp_json_encode( $pins ),
+				current_time( 'mysql' ),
+				$run_id
+			)
+		);
+	}
+
+	/**
+	 * The pinned prompt versions for a run.
+	 *
+	 * @param string $run_id Pipeline run UUID.
+	 * @return array<string, int> prompt_key => version ({} when none).
+	 */
+	public static function get_pins( string $run_id ): array {
+		$run = self::get_run( $run_id );
+		if ( null === $run || empty( $run['pinned_prompts_json'] ) ) {
+			return array();
+		}
+		$pins = json_decode( (string) $run['pinned_prompts_json'], true );
+		return is_array( $pins ) ? array_map( 'intval', $pins ) : array();
+	}
+
+	/**
+	 * Move a run to a new status. Forward transitions only touch open
+	 * (pending/running) runs; `halted` and `failed` are sticky and `done`
+	 * cannot overwrite them.
+	 *
+	 * @param string $run_id Pipeline run UUID.
+	 * @param string $status One of done|failed|halted|running.
+	 * @return bool True when a row transitioned.
+	 */
+	public static function mark_status( string $run_id, string $status ): bool {
+		if ( '' === $run_id || ! self::is_available() ) {
+			return false;
+		}
+		if ( ! in_array( $status, array( 'running', 'done', 'failed', 'halted' ), true ) ) {
+			return false;
+		}
+		global $wpdb;
+		$table    = self::table_name();
+		$now      = current_time( 'mysql' );
+		$finished = in_array( $status, array( 'done', 'failed', 'halted' ), true ) ? $now : null;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$updated = $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE {$table} SET status = %s, updated_at = %s, finished_at = %s
+				WHERE run_id = %s AND status IN ('pending','running')",
+				$status,
+				$now,
+				$finished,
+				$run_id
+			)
+		);
+		return $updated >= 1;
+	}
+
+	/**
+	 * Record by how much a breaching reservation exceeded the ceiling.
+	 *
+	 * @param string $run_id  Pipeline run UUID.
+	 * @param float  $overage USD amount over the ceiling.
+	 * @return void
+	 */
+	public static function record_overage( string $run_id, float $overage ): void {
+		if ( '' === $run_id || $overage <= 0 || ! self::is_available() ) {
+			return;
+		}
+		global $wpdb;
+		$table = self::table_name();
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$wpdb->query(
+			$wpdb->prepare(
+				"UPDATE {$table} SET overage_usd = GREATEST(overage_usd, %f), updated_at = %s WHERE run_id = %s",
+				$overage,
+				current_time( 'mysql' ),
+				$run_id
+			)
+		);
+	}
+
+	/**
+	 * Recent halted runs, for the Review Queue surface.
+	 *
+	 * @param int $limit Max rows (default 10).
+	 * @return array<int, array<string, mixed>>
+	 */
+	public static function halted_runs( int $limit = 10 ): array {
+		if ( ! self::is_available() ) {
+			return array();
+		}
+		global $wpdb;
+		$table = self::table_name();
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT * FROM {$table} WHERE status = 'halted' ORDER BY updated_at DESC LIMIT %d",
+				$limit
+			),
+			ARRAY_A
+		);
+		return is_array( $rows ) ? $rows : array();
+	}
+
+	/** Reset per-request caches (tests). */
+	public static function flush_cache(): void {
+		self::$table_ok = null;
+	}
+}

--- a/includes/core/class-stage-display-map.php
+++ b/includes/core/class-stage-display-map.php
@@ -1,0 +1,172 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * phpcs:ignore WordPress.Files.FileName.InvalidClassFileName -- class naming convention differs from WordPress standard
+ *
+ * Display map for every generation_log / run_stages `stage` value, old and new.
+ *
+ * What: Single source of truth that renders historical stage values
+ *       (analysis, outline, draft, polish, review, llm_research, image_a,
+ *       image_b, image_prompt_rewrite, opik_eval_judge), the Pipeline v2
+ *       vocabulary (research, curate, draft, editorial, seo, publish), and
+ *       any unknown value (humanized fallback) coherently. Also maps each
+ *       stage to its default agent role and primary prompt-registry key so
+ *       audit stamping never hardcodes those associations at call sites.
+ *       The `stage` column is VARCHAR — this PHP map is the vocabulary,
+ *       there is no SQL enum.
+ * Who triggers it: Cost_Tracker (stamping), audit/metrics rendering, Run_State.
+ * Dependencies: none — pure static lookup.
+ *
+ * @see core/class-cost-tracker.php    — Derives agent_role / prompt key when not passed.
+ * @see core/class-prompt-registry.php — Owns the prompt keys referenced here.
+ * @see ARCHITECTURE.md                — Stage vocabulary (canonical edit-stage name: polish).
+ */
+class PRAutoBlogger_Stage_Display_Map {
+
+	/**
+	 * Stage definitions: label (translated lazily), default agent role,
+	 * and the primary prompt-registry key the stage renders with (null
+	 * when the stage has no registry-managed prompt).
+	 *
+	 * @var array<string, array{label: string, role: ?string, prompt_key: ?string}>
+	 */
+	private const MAP = array(
+		// ── Historical vocabulary (rows that exist on prod) ─────────────
+		'analysis'             => array(
+			'label'      => 'Topic Analysis',
+			'role'       => 'analyst',
+			'prompt_key' => 'analysis.system',
+		),
+		'outline'              => array(
+			'label'      => 'Outline',
+			'role'       => 'writer',
+			'prompt_key' => 'content.outline',
+		),
+		'draft'                => array(
+			'label'      => 'Draft',
+			'role'       => 'writer',
+			'prompt_key' => 'content.draft',
+		),
+		'polish'               => array(
+			'label'      => 'Polish',
+			'role'       => 'writer',
+			'prompt_key' => 'content.polish',
+		),
+		'review'               => array(
+			'label'      => 'Editorial Review',
+			'role'       => 'editor',
+			'prompt_key' => 'editor.system',
+		),
+		'llm_research'         => array(
+			'label'      => 'LLM Research',
+			'role'       => 'researcher',
+			'prompt_key' => 'research.system',
+		),
+		'image_a'              => array(
+			'label'      => 'Image A',
+			'role'       => 'illustrator',
+			'prompt_key' => 'image.style_template',
+		),
+		'image_b'              => array(
+			'label'      => 'Image B',
+			'role'       => 'illustrator',
+			'prompt_key' => 'image.style_template',
+		),
+		'image_prompt_rewrite' => array(
+			'label'      => 'Image Prompt Rewrite',
+			'role'       => 'illustrator',
+			'prompt_key' => 'image.rewriter_system',
+		),
+		'opik_eval_judge'      => array(
+			'label'      => 'Opik Eval Judge',
+			'role'       => 'judge',
+			'prompt_key' => null,
+		),
+		// ── Pipeline v2 vocabulary (new runs may write these) ───────────
+		'research'             => array(
+			'label'      => 'Research',
+			'role'       => 'researcher',
+			'prompt_key' => 'research.system',
+		),
+		'curate'               => array(
+			'label'      => 'Curate',
+			'role'       => 'curator',
+			'prompt_key' => null,
+		),
+		'editorial'            => array(
+			'label'      => 'Editorial Loop',
+			'role'       => 'editor',
+			'prompt_key' => null,
+		),
+		'seo'                  => array(
+			'label'      => 'SEO',
+			'role'       => 'seo',
+			'prompt_key' => null,
+		),
+		'publish'              => array(
+			'label'      => 'Publish',
+			'role'       => 'publisher',
+			'prompt_key' => null,
+		),
+	);
+
+	/**
+	 * Human-readable label for a stage value. Unknown stages are humanized
+	 * (underscores to spaces, words capitalized) so the audit view never
+	 * renders blank for a value this map predates or postdates.
+	 *
+	 * @param string $stage Raw stage value from the database.
+	 * @return string Translated display label.
+	 */
+	public static function label( string $stage ): string {
+		if ( isset( self::MAP[ $stage ] ) ) {
+			// phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText -- labels are a fixed const set.
+			return __( self::MAP[ $stage ]['label'], 'prautoblogger' );
+		}
+		return ucwords( str_replace( array( '_', '-' ), ' ', $stage ) );
+	}
+
+	/**
+	 * Default agent role recorded for a stage when the call site does not
+	 * pass one explicitly. Null for unknown stages (column stays NULL).
+	 *
+	 * @param string $stage Raw stage value.
+	 * @return string|null Agent role slug, or null when unknown.
+	 */
+	public static function default_agent_role( string $stage ): ?string {
+		return self::MAP[ $stage ]['role'] ?? null;
+	}
+
+	/**
+	 * Primary prompt-registry key a stage renders with. Used to resolve the
+	 * pinned prompt_version stamped on generation_log rows when the call
+	 * site does not pass an explicit key (e.g. single-pass passes
+	 * 'content.single_pass' for its 'draft' row).
+	 *
+	 * @param string $stage Raw stage value.
+	 * @return string|null Registry key, or null when the stage has none.
+	 */
+	public static function default_prompt_key( string $stage ): ?string {
+		return self::MAP[ $stage ]['prompt_key'] ?? null;
+	}
+
+	/**
+	 * Whether the stage value is part of the known vocabulary.
+	 *
+	 * @param string $stage Raw stage value.
+	 * @return bool True when the stage is a known historical or v2 value.
+	 */
+	public static function is_known( string $stage ): bool {
+		return isset( self::MAP[ $stage ] );
+	}
+
+	/**
+	 * The full vocabulary, for audit listings and tests.
+	 *
+	 * @return array<string, array{label: string, role: ?string, prompt_key: ?string}>
+	 */
+	public static function all(): array {
+		return self::MAP;
+	}
+}

--- a/includes/models/class-generation-log.php
+++ b/includes/models/class-generation-log.php
@@ -26,6 +26,8 @@ class PRAutoBlogger_Generation_Log {
 	private ?string $request_json;
 	private string $response_status;
 	private ?string $error_message;
+	private ?string $agent_role;
+	private ?string $prompt_version;
 	private string $created_at;
 
 	/**
@@ -44,6 +46,8 @@ class PRAutoBlogger_Generation_Log {
 		$this->request_json      = $data['request_json'] ?? null;
 		$this->response_status   = $data['response_status'] ?? 'success';
 		$this->error_message     = $data['error_message'] ?? null;
+		$this->agent_role        = $data['agent_role'] ?? null;
+		$this->prompt_version    = isset( $data['prompt_version'] ) ? (string) $data['prompt_version'] : null;
 		$this->created_at        = $data['created_at'] ?? current_time( 'mysql' );
 	}
 
@@ -71,6 +75,10 @@ class PRAutoBlogger_Generation_Log {
 		return $this->response_status; }
 	public function get_error_message(): ?string {
 		return $this->error_message; }
+	public function get_agent_role(): ?string {
+		return $this->agent_role; }
+	public function get_prompt_version(): ?string {
+		return $this->prompt_version; }
 	public function get_created_at(): string {
 		return $this->created_at; }
 
@@ -90,6 +98,8 @@ class PRAutoBlogger_Generation_Log {
 			'request_json'      => $this->request_json,
 			'response_status'   => $this->response_status,
 			'error_message'     => $this->error_message,
+			'agent_role'        => $this->agent_role,
+			'prompt_version'    => $this->prompt_version,
 			'created_at'        => $this->created_at,
 		);
 	}

--- a/includes/providers/class-llm-research-provider.php
+++ b/includes/providers/class-llm-research-provider.php
@@ -123,25 +123,9 @@ class PRAutoBlogger_LLM_Research_Provider implements PRAutoBlogger_Source_Provid
 	 * @return string
 	 */
 	private function build_system_prompt(): string {
-		return 'You are a deep research analyst specializing in emerging trends, '
-			. 'scientific developments, and community knowledge in niche health and '
-			. "biohacking domains. Your task is to identify substantive, actionable findings.\n\n"
-			. "Using your training knowledge, scan across:\n"
-			. "- Recent scientific literature and research directions\n"
-			. "- Active community discussions, debates, and evolving consensus\n"
-			. "- Emerging products, protocols, and methodologies gaining traction\n"
-			. "- Common questions, misconceptions, and points of confusion\n"
-			. "- Regulatory changes, safety concerns, and legal shifts\n"
-			. "- Gaps between what practitioners want to know and what content exists\n\n"
-			. "Your findings must be:\n"
-			. "1. SUBSTANTIVE — 2-3 paragraphs of detailed analysis per finding, not a headline\n"
-			. "2. ACTIONABLE — practical enough to seed a full article\n"
-			. "3. REALISTIC — grounded in what is actually discussed or researched; do NOT invent citations\n"
-			. "4. TIMELY — reflect current knowledge, recent shifts, or emerging questions\n\n"
-			. "Respond with valid JSON only (no preamble, no markdown fences):\n"
-			. '{"findings": [{"title": "string", "content": "string (2-3 paragraphs)", '
-			. '"relevance_score": 0-100, "category": "question|trend|comparison|guide|misconception|safety"}]}' . "\n\n"
-			. 'Generate 8-12 findings. Prioritize depth over breadth. Avoid generic or surface-level topics.';
+		// v0.18.0: renders from the versioned registry ('research.system')
+		// with a byte-identical in-code fallback.
+		return PRAutoBlogger_Prompt_Registry::render( 'research.system' );
 	}
 
 	/**

--- a/includes/providers/class-open-router-pricing.php
+++ b/includes/providers/class-open-router-pricing.php
@@ -132,7 +132,9 @@ class PRAutoBlogger_OpenRouter_Pricing {
 	/**
 	 * Estimate the cost of an API call in USD.
 	 *
-	 * Uses hardcoded pricing first, falls back to cached model data.
+	 * Uses hardcoded pricing first, falls back to cached model data. IDs
+	 * carrying a date-snapshot suffix that miss both sources are retried
+	 * once as their base ID (see resolve_pricing()).
 	 *
 	 * @param string $model            Model identifier.
 	 * @param int    $prompt_tokens     Input tokens.
@@ -146,18 +148,7 @@ class PRAutoBlogger_OpenRouter_Pricing {
 			return 0.0;
 		}
 
-		$pricing = self::MODEL_PRICING[ $model ] ?? null;
-
-		// Fall back to cached model list pricing.
-		if ( null === $pricing ) {
-			$models = $this->get_available_models();
-			foreach ( $models as $m ) {
-				if ( $m['id'] === $model && isset( $m['pricing'] ) ) {
-					$pricing = $m['pricing'];
-					break;
-				}
-			}
-		}
+		$pricing = $this->resolve_pricing( $model );
 
 		if ( null === $pricing ) {
 			// Unknown model — use a conservative estimate.
@@ -170,6 +161,82 @@ class PRAutoBlogger_OpenRouter_Pricing {
 
 		return ( $prompt_tokens * $pricing['prompt'] / 1000000 )
 			+ ( $completion_tokens * $pricing['completion'] / 1000000 );
+	}
+
+	/**
+	 * Resolve pricing for a model ID, normalizing dated snapshot IDs.
+	 *
+	 * Tries the exact ID first. On a miss, strips a trailing date-snapshot
+	 * suffix and retries once with the base ID: OpenRouter responses can
+	 * name a dated snapshot of the requested model (e.g. request
+	 * 'deepseek/deepseek-v4-flash', response model
+	 * 'deepseek/deepseek-v4-flash-20260423') while pricing sources only
+	 * list the base ID. Every cost path (governor reserve/settle and
+	 * generation-log booking) prices through this seam, so all of them
+	 * survive snapshot IDs instead of booking the conservative estimate.
+	 *
+	 * Side effects: may fetch the models list over HTTP on cache miss
+	 * (via get_available_models()).
+	 *
+	 * @param string $model Model ID as requested, or as returned by the API.
+	 *
+	 * @return array{prompt: float, completion: float}|null Per-million USD pricing, or null when unknown.
+	 */
+	private function resolve_pricing( string $model ): ?array {
+		$pricing = $this->lookup_pricing( $model );
+		if ( null !== $pricing ) {
+			return $pricing;
+		}
+
+		$base = $this->strip_snapshot_suffix( $model );
+		if ( $base !== $model ) {
+			return $this->lookup_pricing( $base );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Look up one exact model ID: hardcoded table first, then cached model list.
+	 *
+	 * Side effects: may fetch the models list over HTTP on cache miss
+	 * (via get_available_models()).
+	 *
+	 * @param string $model Model ID (exact match, no normalization).
+	 *
+	 * @return array{prompt: float, completion: float}|null Per-million USD pricing, or null on miss.
+	 */
+	private function lookup_pricing( string $model ): ?array {
+		$pricing = self::MODEL_PRICING[ $model ] ?? null;
+		if ( null !== $pricing ) {
+			return $pricing;
+		}
+
+		foreach ( $this->get_available_models() as $m ) {
+			if ( $m['id'] === $model && isset( $m['pricing'] ) ) {
+				return $m['pricing'];
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Strip a trailing date-snapshot suffix (e.g. '-20260423') from a model ID.
+	 *
+	 * Only a dash followed by an 8-digit, 20-prefixed date at the very end
+	 * is treated as a snapshot suffix. Any other trailing digit run (e.g.
+	 * 'foo-202612345') is part of the model name and left untouched.
+	 *
+	 * Side effects: none — pure string transformation.
+	 *
+	 * @param string $model Model ID.
+	 *
+	 * @return string Base model ID, or the input unchanged when no snapshot suffix is present.
+	 */
+	private function strip_snapshot_suffix( string $model ): string {
+		$base = preg_replace( '/-20\d{6}$/', '', $model );
+		return is_string( $base ) ? $base : $model;
 	}
 
 	/**

--- a/includes/providers/class-open-router-provider.php
+++ b/includes/providers/class-open-router-provider.php
@@ -11,7 +11,9 @@ declare(strict_types=1);
  * separate provider integrations.
  *
  * Triggered by: Content_Analyzer, Content_Generator, Chief_Editor, Metrics_Collector.
- * Dependencies: PRAutoBlogger_Encryption (for API key decryption), wp_remote_post(), PRAutoBlogger_OpenRouter_Pricing.
+ * Dependencies: PRAutoBlogger_Encryption (for API key decryption), wp_remote_post(),
+ *               PRAutoBlogger_OpenRouter_Pricing, PRAutoBlogger_Cost_Governor (per-run
+ *               reserve-before-call guard around every chat completion).
  *
  * @see interface-llm-provider.php            — Interface this class implements.
  * @see class-open-router-config.php          — Config helpers (base URL, cache TTL).
@@ -51,30 +53,14 @@ class PRAutoBlogger_OpenRouter_Provider implements PRAutoBlogger_LLM_Provider_In
 	 * }
 	 *
 	 * @throws \RuntimeException On API error after retries exhausted.
+	 * @throws PRAutoBlogger_Cost_Ceiling_Exception When the per-run cost governor blocks
+	 *                                              the call (run already halted).
 	 */
 	public function send_chat_completion( array $messages, string $model, array $options = array() ): array {
-		$api_key = $this->get_api_key();
-		if ( '' === $api_key ) {
-			throw new \RuntimeException(
-				__( 'OpenRouter API key is not configured. Go to PRAutoBlogger → Settings.', 'prautoblogger' )
-			);
-		}
-
-		// Validate key format — OpenRouter keys start with "sk-or-".
-		// A key that decrypts to garbage (e.g. after a salt change) won't match.
-		if ( 0 !== strpos( $api_key, 'sk-or-' ) ) {
-			PRAutoBlogger_Logger::instance()->error(
-				sprintf(
-					'Decrypted API key has unexpected format (prefix="%s", len=%d). Re-enter your key in settings.',
-					substr( $api_key, 0, 6 ),
-					strlen( $api_key )
-				),
-				'openrouter'
-			);
-			throw new \RuntimeException(
-				__( 'OpenRouter API key appears corrupted (unexpected format). Please re-enter your key in PRAutoBlogger → Settings.', 'prautoblogger' )
-			);
-		}
+		// Fetch + format-validate the key (moved to Request_Builder in
+		// v0.18.0 for the 300-line cap; behavior unchanged — throws the
+		// same messages on missing/corrupted keys).
+		$api_key = ( new PRAutoBlogger_OpenRouter_Request_Builder() )->resolve_api_key();
 
 		$body = array(
 			'model'    => $model,
@@ -100,6 +86,12 @@ class PRAutoBlogger_OpenRouter_Provider implements PRAutoBlogger_LLM_Provider_In
 				'effort'  => get_option( 'prautoblogger_reasoning_effort', 'medium' ),
 			);
 		}
+
+		// v0.18.0 — per-run cost governor: reserve the worst-case estimate
+		// BEFORE any dispatch. Throws (and the run is already halted) when
+		// the reservation would breach the run ceiling; returns null when
+		// this process is not inside a governed run (historical behavior).
+		$reservation = PRAutoBlogger_Cost_Governor::open_chat_reservation( $model, $messages, $options );
 
 		$last_error = '';
 
@@ -191,8 +183,14 @@ class PRAutoBlogger_OpenRouter_Provider implements PRAutoBlogger_LLM_Provider_In
 					);
 				}
 
-				// Success — parse response.
-				return $parser->parse_success( $data, $model );
+				// Success — parse response, settle the reservation to actuals.
+				$parsed = $parser->parse_success( $data, $model );
+				PRAutoBlogger_Cost_Governor::settle(
+					$reservation,
+					$this->estimate_cost( $model, (int) $parsed['prompt_tokens'], (int) $parsed['completion_tokens'] )
+				);
+				$reservation = null;
+				return $parsed;
 			}
 
 			// All retries exhausted.
@@ -207,6 +205,9 @@ class PRAutoBlogger_OpenRouter_Provider implements PRAutoBlogger_LLM_Provider_In
 		} finally {
 			// Always clean up the cURL filter to avoid leaking into other requests.
 			remove_action( 'http_api_curl', $curl_auth_filter, 99 );
+			// Release any reservation still open (failure/exception path) so
+			// a failed call does not permanently hold its worst-case estimate.
+			PRAutoBlogger_Cost_Governor::release( $reservation );
 		}
 	}
 
@@ -274,18 +275,5 @@ class PRAutoBlogger_OpenRouter_Provider implements PRAutoBlogger_LLM_Provider_In
 	 */
 	public function validate_credentials_detailed(): array {
 		return ( new PRAutoBlogger_OpenRouter_Validator() )->run();
-	}
-
-	/**
-	 * Get the decrypted API key from options.
-	 *
-	 * @return string Decrypted API key, or empty string if not set.
-	 */
-	private function get_api_key(): string {
-		$encrypted = get_option( 'prautoblogger_openrouter_api_key', '' );
-		if ( '' === $encrypted ) {
-			return '';
-		}
-		return PRAutoBlogger_Encryption::decrypt( $encrypted );
 	}
 }

--- a/includes/providers/class-open-router-request-builder.php
+++ b/includes/providers/class-open-router-request-builder.php
@@ -78,4 +78,43 @@ class PRAutoBlogger_OpenRouter_Request_Builder {
 		add_action( 'http_api_curl', $curl_auth_filter, 99, 3 );
 		return $curl_auth_filter;
 	}
+
+	/**
+	 * Fetch, decrypt, and format-validate the OpenRouter API key.
+	 *
+	 * Moved from OpenRouter_Provider in v0.18.0 (300-line cap); the
+	 * messages and behavior are unchanged.
+	 *
+	 * @return string Validated plaintext API key.
+	 * @throws \RuntimeException When the key is missing or has an
+	 *                           unexpected format (corrupted decryption).
+	 */
+	public function resolve_api_key(): string {
+		$encrypted = get_option( 'prautoblogger_openrouter_api_key', '' );
+		$api_key   = '' === $encrypted ? '' : PRAutoBlogger_Encryption::decrypt( $encrypted );
+
+		if ( '' === $api_key ) {
+			throw new \RuntimeException(
+				__( 'OpenRouter API key is not configured. Go to PRAutoBlogger → Settings.', 'prautoblogger' )
+			);
+		}
+
+		// Validate key format — OpenRouter keys start with "sk-or-".
+		// A key that decrypts to garbage (e.g. after a salt change) won't match.
+		if ( 0 !== strpos( $api_key, 'sk-or-' ) ) {
+			PRAutoBlogger_Logger::instance()->error(
+				sprintf(
+					'Decrypted API key has unexpected format (prefix="%s", len=%d). Re-enter your key in settings.',
+					substr( $api_key, 0, 6 ),
+					strlen( $api_key )
+				),
+				'openrouter'
+			);
+			throw new \RuntimeException(
+				__( 'OpenRouter API key appears corrupted (unexpected format). Please re-enter your key in PRAutoBlogger → Settings.', 'prautoblogger' )
+			);
+		}
+
+		return $api_key;
+	}
 }

--- a/prautoblogger.php
+++ b/prautoblogger.php
@@ -9,7 +9,7 @@
  * Plugin Name:       PRAutoBlogger
  * Plugin URI:        https://peptiderepo.com/prautoblogger
  * Description:       Monitors social media for trending topics, generates SEO-friendly blog posts using AI, and publishes them on a daily schedule with full cost tracking and self-improvement metrics.
- * Version:           0.17.0
+ * Version:           0.18.0
  * Requires at least: 6.0
  * Requires PHP:      7.4
  * Author:            PeptideRepo
@@ -35,14 +35,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 | Defined here so every file in the plugin can reference paths, versions,
 | and limits without magic strings.
 */
-define( 'PRAUTOBLOGGER_VERSION', '0.17.0' );
-define( 'PRAUTOBLOGGER_DB_VERSION', '1.1.0' );
+define( 'PRAUTOBLOGGER_VERSION', '0.18.0' );
+define( 'PRAUTOBLOGGER_DB_VERSION', '1.2.0' );
 define( 'PRAUTOBLOGGER_PLUGIN_FILE', __FILE__ );
 define( 'PRAUTOBLOGGER_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PRAUTOBLOGGER_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'PRAUTOBLOGGER_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 // API and retry limits — named constants instead of magic numbers.
 define( 'PRAUTOBLOGGER_MAX_RETRIES', 3 );
+// Pipeline v2 Phase 1 (v0.18.0) defaults. Both are SETTINGS-backed at every
+// read site (prautoblogger_per_run_cost_ceiling_usd /
+// prautoblogger_request_json_retention_days); these constants exist only as
+// the named get_option() fallbacks — never inline the literals.
+define( 'PRAUTOBLOGGER_DEFAULT_RUN_CEILING_USD', 0.50 );
+define( 'PRAUTOBLOGGER_DEFAULT_REQUEST_JSON_RETENTION_DAYS', 14 );
 define( 'PRAUTOBLOGGER_RETRY_BASE_DELAY_SECONDS', 2 );
 define( 'PRAUTOBLOGGER_API_TIMEOUT_SECONDS', 180 );
 define( 'PRAUTOBLOGGER_CACHE_TTL_SECONDS', 3600 );

--- a/templates/admin/review-queue.php
+++ b/templates/admin/review-queue.php
@@ -18,6 +18,37 @@ $bulk_type = isset( $_GET['prautoblogger_bulk_type'] ) ? sanitize_text_field( wp
 <div class="wrap prautoblogger-review-queue">
 	<h1><?php esc_html_e( 'PRAutoBlogger — Review Queue', 'prautoblogger' ); ?></h1>
 
+	<?php if ( ! empty( $halted_runs ) ) : ?>
+		<div class="notice notice-error">
+			<p>
+				<strong><?php esc_html_e( 'Runs halted by the per-run cost ceiling', 'prautoblogger' ); ?></strong>
+				<?php esc_html_e( '— these runs were stopped before exceeding their budget and need human review. Raise the ceiling in Settings or discard the run.', 'prautoblogger' ); ?>
+			</p>
+			<table class="widefat striped" style="margin-bottom: 8px;">
+				<thead>
+					<tr>
+						<th><?php esc_html_e( 'Run ID', 'prautoblogger' ); ?></th>
+						<th><?php esc_html_e( 'Halted at', 'prautoblogger' ); ?></th>
+						<th><?php esc_html_e( 'Spent + held (USD)', 'prautoblogger' ); ?></th>
+						<th><?php esc_html_e( 'Ceiling (USD)', 'prautoblogger' ); ?></th>
+						<th><?php esc_html_e( 'Blocked overage (USD)', 'prautoblogger' ); ?></th>
+					</tr>
+				</thead>
+				<tbody>
+					<?php foreach ( $halted_runs as $halted_run ) : ?>
+						<tr>
+							<td><code><?php echo esc_html( (string) $halted_run['run_id'] ); ?></code></td>
+							<td><?php echo esc_html( (string) ( $halted_run['finished_at'] ?? $halted_run['updated_at'] ) ); ?></td>
+							<td><?php echo esc_html( number_format( (float) $halted_run['settled_usd'] + (float) $halted_run['reserved_usd'], 4 ) ); ?></td>
+							<td><?php echo esc_html( number_format( (float) $halted_run['ceiling_usd'], 2 ) ); ?></td>
+							<td><?php echo esc_html( number_format( (float) $halted_run['overage_usd'], 4 ) ); ?></td>
+						</tr>
+					<?php endforeach; ?>
+				</tbody>
+			</table>
+		</div>
+	<?php endif; ?>
+
 	<?php if ( $bulk_done > 0 && '' !== $bulk_type ) : ?>
 		<div class="notice notice-success is-dismissible">
 			<p>
@@ -86,7 +117,10 @@ $bulk_type = isset( $_GET['prautoblogger_bulk_type'] ) ? sanitize_text_field( wp
 					</tr>
 				</thead>
 				<tbody>
-					<?php while ( $query->have_posts() ) : $query->the_post(); ?>
+					<?php
+					while ( $query->have_posts() ) :
+						$query->the_post();
+						?>
 						<?php
 						$post_id       = get_the_ID();
 						$verdict       = get_post_meta( $post_id, '_prautoblogger_editor_verdict', true );
@@ -139,14 +173,18 @@ $bulk_type = isset( $_GET['prautoblogger_bulk_type'] ) ? sanitize_text_field( wp
 		if ( $total_pages > 1 ) :
 			$current_page = isset( $_GET['paged'] ) ? absint( $_GET['paged'] ) : 1;
 			echo '<div class="prautoblogger-pagination">';
-			echo wp_kses_post( paginate_links( [
-				'base'      => add_query_arg( 'paged', '%#%' ),
-				'format'    => '',
-				'current'   => $current_page,
-				'total'     => $total_pages,
-				'prev_text' => '&laquo;',
-				'next_text' => '&raquo;',
-			] ) );
+			echo wp_kses_post(
+				paginate_links(
+					array(
+						'base'      => add_query_arg( 'paged', '%#%' ),
+						'format'    => '',
+						'current'   => $current_page,
+						'total'     => $total_pages,
+						'prev_text' => '&laquo;',
+						'next_text' => '&raquo;',
+					)
+				)
+			);
 			echo '</div>';
 		endif;
 		?>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,6 +21,14 @@ if ( ! defined( 'PRAB_PLUGIN_DIR' ) ) {
     define( 'PRAB_PLUGIN_DIR', dirname( __DIR__ ) . '/' );
 }
 
+// Pipeline v2 Phase 1 defaults (source of truth: prautoblogger.php).
+if ( ! defined( 'PRAUTOBLOGGER_DEFAULT_RUN_CEILING_USD' ) ) {
+    define( 'PRAUTOBLOGGER_DEFAULT_RUN_CEILING_USD', 0.50 );
+}
+if ( ! defined( 'PRAUTOBLOGGER_DEFAULT_REQUEST_JSON_RETENTION_DAYS' ) ) {
+    define( 'PRAUTOBLOGGER_DEFAULT_REQUEST_JSON_RETENTION_DAYS', 14 );
+}
+
 // WordPress time constants used by CostTracker and ContentAnalyzer.
 if ( ! defined( 'DAY_IN_SECONDS' ) ) {
     define( 'DAY_IN_SECONDS', 86400 );

--- a/tests/unit/Core/CostGovernorTest.php
+++ b/tests/unit/Core/CostGovernorTest.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * Tests for PRAutoBlogger_Cost_Governor.
+ *
+ * Locks the reserve-before-call contract: estimates use prompt-size +
+ * max_tokens against the pricing chain; reservations are atomic
+ * conditional UPDATEs; standalone (no-run) calls are ungoverned; a breach
+ * halts the run and throws Cost_Ceiling_Exception; settle releases the
+ * hold and books actuals.
+ *
+ * @package PRAutoBlogger\Tests\Core
+ */
+
+namespace PRAutoBlogger\Tests\Core;
+
+use PRAutoBlogger\Tests\BaseTestCase;
+
+class CostGovernorTest extends BaseTestCase {
+
+	/**
+	 * @var \PHPUnit\Framework\MockObject\MockObject Mock $wpdb.
+	 */
+	private $wpdb;
+
+	/**
+	 * Captured SQL passed through $wpdb->query().
+	 *
+	 * @var string[]
+	 */
+	private array $queries = array();
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->queries   = array();
+		$this->wpdb      = $this->create_mock_wpdb();
+		$GLOBALS['wpdb'] = $this->wpdb;
+
+		// prepare() passes SQL through with args appended for inspection.
+		$this->wpdb->method( 'prepare' )->willReturnCallback(
+			static function ( $sql, ...$args ) {
+				return $sql . ' /* ' . implode( ',', array_map( 'strval', $args ) ) . ' */';
+			}
+		);
+
+		\PRAutoBlogger_Run_Context::clear();
+		\PRAutoBlogger_Run_State::flush_cache();
+
+		$this->stub_get_option(
+			array(
+				'prautoblogger_per_run_cost_ceiling_usd' => 0.50,
+				'prautoblogger_log_level'                => 'error',
+			)
+		);
+	}
+
+	protected function tearDown(): void {
+		\PRAutoBlogger_Run_Context::clear();
+		\PRAutoBlogger_Run_State::flush_cache();
+		unset( $GLOBALS['wpdb'] );
+		parent::tearDown();
+	}
+
+	/**
+	 * Outside any run, the governor must not govern (historical behavior).
+	 */
+	public function test_no_run_context_means_ungoverned(): void {
+		$reservation = \PRAutoBlogger_Cost_Governor::open_amount_reservation( 0.10, 'test' );
+		$this->assertNull( $reservation );
+	}
+
+	/**
+	 * Estimate = (chars/4 prompt tokens + max_tokens completion) priced by
+	 * the pricing chain. With an unknown model the chain falls back to its
+	 * conservative default pricing, which is still a positive number.
+	 */
+	public function test_estimate_chat_cost_is_positive_and_scales_with_max_tokens(): void {
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => str_repeat( 'a', 400 ), // 100 estimated prompt tokens.
+			),
+		);
+		$small = \PRAutoBlogger_Cost_Governor::estimate_chat_cost(
+			'unknown/model-x',
+			$messages,
+			array( 'max_tokens' => 100 )
+		);
+		$large = \PRAutoBlogger_Cost_Governor::estimate_chat_cost(
+			'unknown/model-x',
+			$messages,
+			array( 'max_tokens' => 4000 )
+		);
+		$this->assertGreaterThan( 0.0, $small );
+		$this->assertGreaterThan( $small, $large );
+	}
+
+	/**
+	 * A winning conditional UPDATE (affected rows = 1) opens a reservation
+	 * carrying the run id and amount.
+	 */
+	public function test_successful_reservation(): void {
+		\PRAutoBlogger_Run_Context::set_run_id( 'run-ok' );
+
+		$this->wpdb->method( 'get_var' )->willReturn( 'wp_prautoblogger_runs' );
+		$this->wpdb->method( 'get_row' )->willReturn(
+			array(
+				'run_id'       => 'run-ok',
+				'status'       => 'running',
+				'ceiling_usd'  => '0.50',
+				'reserved_usd' => '0.00',
+				'settled_usd'  => '0.00',
+				'overage_usd'  => '0.00',
+			)
+		);
+		$this->wpdb->method( 'query' )->willReturnCallback(
+			function ( $sql ) {
+				$this->queries[] = (string) $sql;
+				return 1;
+			}
+		);
+
+		$reservation = \PRAutoBlogger_Cost_Governor::open_amount_reservation( 0.10, 'test' );
+
+		$this->assertIsArray( $reservation );
+		$this->assertSame( 'run-ok', $reservation['run_id'] );
+		$this->assertSame( 0.10, $reservation['amount'] );
+
+		$reserve_sql = implode( "\n", $this->queries );
+		$this->assertStringContainsString( 'reserved_usd + settled_usd', $reserve_sql );
+		$this->assertStringContainsString( "status IN ('pending','running')", $reserve_sql );
+	}
+
+	/**
+	 * A losing conditional UPDATE (affected rows = 0) halts the run,
+	 * records the overage, and throws Cost_Ceiling_Exception.
+	 */
+	public function test_breach_halts_run_and_throws(): void {
+		\PRAutoBlogger_Run_Context::set_run_id( 'run-over' );
+
+		$this->wpdb->method( 'get_var' )->willReturn( 'wp_prautoblogger_runs' );
+		$this->wpdb->method( 'get_row' )->willReturn(
+			array(
+				'run_id'       => 'run-over',
+				'status'       => 'running',
+				'ceiling_usd'  => '0.50',
+				'reserved_usd' => '0.10',
+				'settled_usd'  => '0.38',
+				'overage_usd'  => '0.00',
+			)
+		);
+		$this->wpdb->method( 'query' )->willReturnCallback(
+			function ( $sql ) {
+				$this->queries[] = (string) $sql;
+				// The reserve UPDATE loses; status/overage UPDATEs win.
+				return false !== strpos( (string) $sql, 'reserved_usd + ' ) ? 0 : 1;
+			}
+		);
+		$this->wpdb->method( 'insert' )->willReturn( 1 ); // Logger event row.
+
+		try {
+			\PRAutoBlogger_Cost_Governor::open_amount_reservation( 0.10, 'test' );
+			$this->fail( 'Expected PRAutoBlogger_Cost_Ceiling_Exception.' );
+		} catch ( \PRAutoBlogger_Cost_Ceiling_Exception $e ) {
+			$this->assertStringContainsString( 'run-over', $e->getMessage() );
+		}
+
+		$all_sql = implode( "\n", $this->queries );
+		$this->assertStringContainsString( "status = %s", $all_sql );
+		$this->assertStringContainsString( 'halted', $all_sql );
+		$this->assertStringContainsString( 'overage_usd', $all_sql );
+	}
+
+	/**
+	 * Ceiling 0 on the run row disables per-run governance for that run.
+	 */
+	public function test_zero_ceiling_is_ungoverned(): void {
+		\PRAutoBlogger_Run_Context::set_run_id( 'run-free' );
+
+		$this->wpdb->method( 'get_var' )->willReturn( 'wp_prautoblogger_runs' );
+		$this->wpdb->method( 'get_row' )->willReturn(
+			array(
+				'run_id'       => 'run-free',
+				'status'       => 'running',
+				'ceiling_usd'  => '0',
+				'reserved_usd' => '0.00',
+				'settled_usd'  => '0.00',
+				'overage_usd'  => '0.00',
+			)
+		);
+		$this->wpdb->method( 'query' )->willReturn( 1 );
+
+		$this->assertNull( \PRAutoBlogger_Cost_Governor::open_amount_reservation( 99.0, 'test' ) );
+	}
+
+	/**
+	 * Settle writes the release + actuals UPDATE; null reservations no-op.
+	 */
+	public function test_settle_and_release(): void {
+		\PRAutoBlogger_Cost_Governor::settle( null, 1.0 ); // Must not touch $wpdb.
+
+		$this->wpdb->method( 'get_var' )->willReturn( 'wp_prautoblogger_runs' );
+		$this->wpdb->method( 'query' )->willReturnCallback(
+			function ( $sql ) {
+				$this->queries[] = (string) $sql;
+				return 1;
+			}
+		);
+
+		\PRAutoBlogger_Cost_Governor::settle(
+			array(
+				'run_id' => 'run-ok',
+				'amount' => 0.10,
+			),
+			0.002
+		);
+
+		$sql = implode( "\n", $this->queries );
+		$this->assertStringContainsString( 'GREATEST(reserved_usd - %f, 0)', $sql );
+		$this->assertStringContainsString( 'settled_usd = settled_usd + %f', $sql );
+	}
+}

--- a/tests/unit/Core/PromptRegistryTest.php
+++ b/tests/unit/Core/PromptRegistryTest.php
@@ -1,0 +1,238 @@
+<?php
+/**
+ * Tests for PRAutoBlogger_Prompt_Registry (read side).
+ *
+ * Locks the two load-bearing contracts of the Phase-1 prompt registry:
+ * (1) the in-code fallback renders BYTE-IDENTICAL output to the historical
+ * hardcoded prompt builders when the table is unavailable, and (2) token
+ * substitution uses the exact `{{ name }}` syntax.
+ *
+ * @package PRAutoBlogger\Tests\Core
+ */
+
+namespace PRAutoBlogger\Tests\Core;
+
+use PRAutoBlogger\Tests\BaseTestCase;
+
+class PromptRegistryTest extends BaseTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		// No $wpdb in scope: the registry must read as "unavailable" and
+		// fall back to the in-code defaults without touching the database.
+		unset( $GLOBALS['wpdb'] );
+		\PRAutoBlogger_Prompt_Registry::flush_cache();
+	}
+
+	protected function tearDown(): void {
+		\PRAutoBlogger_Prompt_Registry::flush_cache();
+		parent::tearDown();
+	}
+
+	/**
+	 * Token filling: exact `{{ name }}` placeholders, multiple occurrences,
+	 * unknown tokens left intact.
+	 */
+	public function test_fill_substitutes_tokens(): void {
+		$body = 'A {{ one }} B {{ two }} C {{ one }} D {{ missing }}';
+		$out  = \PRAutoBlogger_Prompt_Registry::fill(
+			$body,
+			array(
+				'one' => 'X',
+				'two' => 'Y',
+			)
+		);
+		$this->assertSame( 'A X B Y C X D {{ missing }}', $out );
+	}
+
+	/**
+	 * With no table available, render() must produce the same single-pass
+	 * prompt the v0.16.0 sprintf produced, byte for byte.
+	 */
+	public function test_single_pass_fallback_matches_historical_output(): void {
+		$rendered = \PRAutoBlogger_Prompt_Registry::render(
+			'content.single_pass',
+			array(
+				'title'        => 'My Title',
+				'topic'        => 'My Topic',
+				'article_type' => 'guide',
+				'key_points'   => implode( "\n- ", array( 'p1', 'p2' ) ),
+				'keywords'     => implode( ', ', array( 'k1', 'k2' ) ),
+				'min_words'    => '800',
+				'max_words'    => '2000',
+			)
+		);
+
+		$historical = sprintf(
+			"Write a complete blog post in HTML format.\n\n" .
+			"Title: %s\nTopic: %s\nType: %s\n\nKey points:\n- %s\n\n" .
+			"Keywords: %s\n\n" .
+			"Requirements:\n" .
+			"- %d-%d words\n" .
+			"- Proper HTML (h2, h3, p, ul/li)\n" .
+			"- Engaging intro, strong conclusion with CTA\n" .
+			"- Do NOT include the title or <html>/<body> tags\n" .
+			"- Output HTML only, no markdown or commentary\n" .
+			'- Follow EVERY formatting and structural requirement from your system prompt style guide',
+			'My Title',
+			'My Topic',
+			'guide',
+			implode( "\n- ", array( 'p1', 'p2' ) ),
+			implode( ', ', array( 'k1', 'k2' ) ),
+			800,
+			2000
+		);
+
+		$this->assertSame( $historical, $rendered );
+	}
+
+	/**
+	 * Outline fallback matches the historical sprintf output byte for byte.
+	 */
+	public function test_outline_fallback_matches_historical_output(): void {
+		$rendered = \PRAutoBlogger_Prompt_Registry::render(
+			'content.outline',
+			array(
+				'title'        => 'T',
+				'topic'        => 'Top',
+				'article_type' => 'guide',
+				'key_points'   => implode( "\n- ", array( 'a', 'b' ) ),
+				'keywords'     => 'k1, k2',
+				'min_words'    => '800',
+				'max_words'    => '2000',
+			)
+		);
+
+		$historical = sprintf(
+			"Create a detailed outline for a blog post titled: \"%s\"\n\n" .
+			"Topic: %s\nArticle type: %s\n\nKey points to cover:\n%s\n\n" .
+			"Target keywords: %s\n\n" .
+			'The outline should have 4-6 main sections with bullet points under each. ' .
+			'Include an introduction hook and a conclusion with a call to action. ' .
+			"Word count target: %d-%d words.\n\n" .
+			'Plan the structure to satisfy EVERY requirement in your system prompt style guide.',
+			'T',
+			'Top',
+			'guide',
+			implode( "\n- ", array( 'a', 'b' ) ),
+			'k1, k2',
+			800,
+			2000
+		);
+
+		$this->assertSame( $historical, $rendered );
+	}
+
+	/**
+	 * Polish fallback matches the historical concatenation byte for byte.
+	 */
+	public function test_polish_fallback_matches_historical_output(): void {
+		$rendered = \PRAutoBlogger_Prompt_Registry::render(
+			'content.polish',
+			array( 'draft' => '<p>Hello</p>' )
+		);
+
+		$historical = "Review and polish this blog post draft. Improve:\n" .
+			"1. Flow and readability\n" .
+			"2. SEO optimization (headings, keyword placement)\n" .
+			"3. Engagement (hooks, transitions, call-to-action)\n" .
+			"4. Accuracy and clarity\n" .
+			"5. Remove any filler or redundant sentences\n\n" .
+			'IMPORTANT: Preserve all bullet points, numbered lists, hyperlinks, and ' .
+			'structural elements from the draft. Do NOT flatten lists into prose or ' .
+			'remove links. Ensure every requirement from your system prompt style ' .
+			"guide is satisfied in the final output.\n\n" .
+			"Return the polished HTML content only. Do not add commentary.\n\n" .
+			"DRAFT:\n" . '<p>Hello</p>';
+
+		$this->assertSame( $historical, $rendered );
+	}
+
+	/**
+	 * Editor system fallback matches the historical builder for both the
+	 * empty and the populated instructions paths.
+	 */
+	public function test_editor_system_fallback_matches_historical_output(): void {
+		$expected_plain = 'You are a senior blog editor specializing in peptides content'
+			. ". Review article drafts before publication.\n\n"
+			. "Evaluate on: QUALITY, ACCURACY, SEO, COMPLETENESS, READABILITY.\n"
+			. "Respond with JSON: {\n"
+			. '  "verdict": "approved" | "revised" | "rejected",' . "\n"
+			. '  "quality_score": 0.0-1.0,' . "\n"
+			. '  "seo_score": 0.0-1.0,' . "\n"
+			. '  "issues": ["issue1", "issue2"],' . "\n"
+			. '  "notes": "Editorial notes",' . "\n"
+			. '  "revised_content": "Full revised HTML if revised, null otherwise"' . "\n"
+			. "}\n\n"
+			. "Rules:\n"
+			. "- APPROVE if quality_score >= 0.7 and seo_score >= 0.6\n"
+			. "- REVISE if fixable issues exist — provide full revised HTML\n"
+			. "- REJECT if fundamentally flawed\n"
+			. "- Preserve formatting, links, lists when revising\n";
+
+		$rendered = \PRAutoBlogger_Prompt_Registry::render(
+			'editor.system',
+			array(
+				'niche_clause'       => ' specializing in peptides content',
+				'instructions_block' => '',
+			)
+		);
+		$this->assertSame( $expected_plain, $rendered );
+
+		$rendered_with = \PRAutoBlogger_Prompt_Registry::render(
+			'editor.system',
+			array(
+				'niche_clause'       => '',
+				'instructions_block' => "\nAdditional instructions:\nBe terse.\n",
+			)
+		);
+		$this->assertStringEndsWith(
+			"- Preserve formatting, links, lists when revising\n\nAdditional instructions:\nBe terse.\n",
+			$rendered_with
+		);
+	}
+
+	/**
+	 * Every registry key advertised in the plan has a default body, and the
+	 * stage map's prompt keys all resolve to a known key.
+	 */
+	public function test_defs_cover_all_planned_keys(): void {
+		$defs = \PRAutoBlogger_Prompt_Registry::defs();
+		$keys = array(
+			'content.system',
+			'content.single_pass',
+			'content.outline',
+			'content.draft',
+			'content.polish',
+			'analysis.system',
+			'analysis.user',
+			'editor.system',
+			'editor.review',
+			'research.system',
+			'image.rewriter_system',
+			'image.style_template',
+		);
+		foreach ( $keys as $key ) {
+			$this->assertArrayHasKey( $key, $defs, "Missing registry def for '{$key}'" );
+			$this->assertNotSame( '', $defs[ $key ]['body'] );
+		}
+
+		foreach ( \PRAutoBlogger_Stage_Display_Map::all() as $stage => $def ) {
+			if ( null !== $def['prompt_key'] ) {
+				$this->assertArrayHasKey(
+					$def['prompt_key'],
+					$defs,
+					"Stage '{$stage}' maps to unknown prompt key '{$def['prompt_key']}'"
+				);
+			}
+		}
+	}
+
+	/**
+	 * pins_for_run is empty (not an error) when no run / table is present.
+	 */
+	public function test_pins_empty_without_table(): void {
+		$this->assertSame( array(), \PRAutoBlogger_Prompt_Registry::pins_for_run( null ) );
+		$this->assertSame( array(), \PRAutoBlogger_Prompt_Registry::pins_for_run( 'run-x' ) );
+	}
+}

--- a/tests/unit/Core/RunReaperTest.php
+++ b/tests/unit/Core/RunReaperTest.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Tests for PRAutoBlogger_Run_Reaper.
+ *
+ * Locks the retention contract (R days from the SETTING, 0 = keep
+ * forever) and the stuck-sweep SQL shapes (2x expected wall-clock,
+ * running-only).
+ *
+ * @package PRAutoBlogger\Tests\Core
+ */
+
+namespace PRAutoBlogger\Tests\Core;
+
+use PRAutoBlogger\Tests\BaseTestCase;
+use Brain\Monkey\Functions;
+
+class RunReaperTest extends BaseTestCase {
+
+	/**
+	 * @var \PHPUnit\Framework\MockObject\MockObject Mock $wpdb.
+	 */
+	private $wpdb;
+
+	/**
+	 * Captured SQL passed through $wpdb->query().
+	 *
+	 * @var string[]
+	 */
+	private array $queries = array();
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->queries = array();
+		// Local mock: the reaper also uses get_col(), which the shared
+		// BaseTestCase mock does not declare.
+		$this->wpdb = $this->getMockBuilder( \stdClass::class )
+			->addMethods( array( 'prepare', 'get_var', 'get_results', 'get_col', 'insert', 'query', 'get_row', 'update' ) )
+			->getMock();
+		$this->wpdb->prefix     = 'wp_';
+		$this->wpdb->insert_id  = 0;
+		$this->wpdb->last_error = '';
+		$GLOBALS['wpdb']        = $this->wpdb;
+		$this->wpdb->method( 'prepare' )->willReturnCallback(
+			static function ( $sql, ...$args ) {
+				return $sql . ' /* ' . implode( ',', array_map( 'strval', $args ) ) . ' */';
+			}
+		);
+		Functions\when( 'apply_filters' )->returnArg( 2 );
+		\PRAutoBlogger_Run_State::flush_cache();
+		\PRAutoBlogger_Run_Stage_State::flush_cache();
+	}
+
+	protected function tearDown(): void {
+		\PRAutoBlogger_Run_State::flush_cache();
+		\PRAutoBlogger_Run_Stage_State::flush_cache();
+		unset( $GLOBALS['wpdb'] );
+		parent::tearDown();
+	}
+
+	/**
+	 * Retention 0 (or negative) means "keep forever": the pruner must not
+	 * issue any UPDATE.
+	 */
+	public function test_zero_retention_keeps_payloads_forever(): void {
+		$this->stub_get_option(
+			array(
+				'prautoblogger_request_json_retention_days' => 0,
+			)
+		);
+		$this->wpdb->method( 'get_var' )->willReturn( null );   // No state tables.
+		$this->wpdb->method( 'get_col' )->willReturn( array() );
+		$this->wpdb->expects( $this->never() )->method( 'query' );
+
+		$stats = \PRAutoBlogger_Run_Reaper::reap();
+		$this->assertSame( 0, $stats['payloads_pruned'] );
+	}
+
+	/**
+	 * With the default setting the pruner NULLs request_json older than R
+	 * days on the generation log (and stage payloads when that table
+	 * exists). The sweeps only touch 'running'/open rows.
+	 */
+	public function test_reap_prunes_and_sweeps_with_setting_backed_window(): void {
+		$this->stub_get_option(
+			array(
+				'prautoblogger_request_json_retention_days' => PRAUTOBLOGGER_DEFAULT_REQUEST_JSON_RETENTION_DAYS,
+			)
+		);
+		// Both state tables exist.
+		$this->wpdb->method( 'get_var' )->willReturnCallback(
+			static function ( $sql ) {
+				if ( false !== strpos( (string) $sql, 'run_stages' ) ) {
+					return 'wp_prautoblogger_run_stages';
+				}
+				return 'wp_prautoblogger_runs';
+			}
+		);
+		$this->wpdb->method( 'get_col' )->willReturn( array() ); // No stuck runs.
+		$this->wpdb->method( 'query' )->willReturnCallback(
+			function ( $sql ) {
+				$this->queries[] = (string) $sql;
+				return 2;
+			}
+		);
+
+		$stats = \PRAutoBlogger_Run_Reaper::reap();
+
+		$all_sql = implode( "\n", $this->queries );
+		$this->assertStringContainsString( 'request_json = NULL', $all_sql );
+		$this->assertStringContainsString( 'meta_json = NULL', $all_sql );
+		$this->assertStringContainsString( "status = 'failed'", $all_sql );
+		$this->assertStringContainsString( "WHERE status = 'running' AND updated_at <", $all_sql );
+		$this->assertSame( 4, $stats['payloads_pruned'] ); // 2 rows x 2 tables.
+	}
+}

--- a/tests/unit/Core/RunStageStateTest.php
+++ b/tests/unit/Core/RunStageStateTest.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Tests for PRAutoBlogger_Run_Stage_State.
+ *
+ * Locks the idempotency-key contract (item scoping for multi-article
+ * runs), the sticky-done upsert semantics, and the self-healing
+ * no-table degradation.
+ *
+ * @package PRAutoBlogger\Tests\Core
+ */
+
+namespace PRAutoBlogger\Tests\Core;
+
+use PRAutoBlogger\Tests\BaseTestCase;
+
+class RunStageStateTest extends BaseTestCase {
+
+	/**
+	 * @var \PHPUnit\Framework\MockObject\MockObject Mock $wpdb.
+	 */
+	private $wpdb;
+
+	/**
+	 * Captured SQL passed through $wpdb->query().
+	 *
+	 * @var string[]
+	 */
+	private array $queries = array();
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->queries   = array();
+		$this->wpdb      = $this->create_mock_wpdb();
+		$GLOBALS['wpdb'] = $this->wpdb;
+		$this->wpdb->method( 'prepare' )->willReturnCallback(
+			static function ( $sql, ...$args ) {
+				return $sql . ' /* ' . implode( ',', array_map( 'strval', $args ) ) . ' */';
+			}
+		);
+		\PRAutoBlogger_Run_Stage_State::flush_cache();
+	}
+
+	protected function tearDown(): void {
+		\PRAutoBlogger_Run_Stage_State::flush_cache();
+		unset( $GLOBALS['wpdb'] );
+		parent::tearDown();
+	}
+
+	/**
+	 * Two different ideas in the same run must get different item keys
+	 * (one run_id spans all N articles of a batch run); the same idea must
+	 * hash stably across processes (queue serialization round-trip).
+	 */
+	public function test_item_keys_scope_articles_within_a_run(): void {
+		$idea_a = new \PRAutoBlogger_Article_Idea(
+			array(
+				'topic'           => 'BPC-157 dosing',
+				'article_type'    => 'guide',
+				'suggested_title' => 'BPC-157 Dosing Guide',
+				'summary'         => 's',
+			)
+		);
+		$idea_b = new \PRAutoBlogger_Article_Idea(
+			array(
+				'topic'           => 'TB-500 storage',
+				'article_type'    => 'question',
+				'suggested_title' => 'How To Store TB-500',
+				'summary'         => 's',
+			)
+		);
+		$idea_a_again = new \PRAutoBlogger_Article_Idea( $idea_a->to_array() );
+
+		$key_a = \PRAutoBlogger_Run_Stage_State::item_key_for_idea( $idea_a );
+		$key_b = \PRAutoBlogger_Run_Stage_State::item_key_for_idea( $idea_b );
+
+		$this->assertNotSame( $key_a, $key_b );
+		$this->assertSame( $key_a, \PRAutoBlogger_Run_Stage_State::item_key_for_idea( $idea_a_again ) );
+		$this->assertStringStartsWith( 'idea:', $key_a );
+		$this->assertLessThanOrEqual( 64, strlen( $key_a ) );
+		$this->assertSame(
+			\PRAutoBlogger_Run_Stage_State::idea_hash( $idea_a ),
+			substr( $key_a, 5 )
+		);
+	}
+
+	/**
+	 * start() upserts must never demote a done stage and must bump attempt
+	 * on re-entry; done() must be sticky.
+	 */
+	public function test_start_upsert_protects_done_status(): void {
+		$this->wpdb->method( 'get_var' )->willReturn( 'wp_prautoblogger_run_stages' );
+		$this->wpdb->method( 'query' )->willReturnCallback(
+			function ( $sql ) {
+				$this->queries[] = (string) $sql;
+				return 1;
+			}
+		);
+
+		\PRAutoBlogger_Run_Stage_State::start( 'run-1', 'draft', '', 'idea:abc' );
+
+		$sql = implode( "\n", $this->queries );
+		$this->assertStringContainsString( 'ON DUPLICATE KEY UPDATE', $sql );
+		$this->assertStringContainsString( "IF(status = 'done', attempt, attempt + 1)", $sql );
+		$this->assertStringContainsString( "IF(status = 'done', 'done', 'running')", $sql );
+	}
+
+	/**
+	 * fail() and fail_open_for_item() must never touch done rows.
+	 */
+	public function test_fail_paths_exclude_done_rows(): void {
+		$this->wpdb->method( 'get_var' )->willReturn( 'wp_prautoblogger_run_stages' );
+		$this->wpdb->method( 'query' )->willReturnCallback(
+			function ( $sql ) {
+				$this->queries[] = (string) $sql;
+				return 1;
+			}
+		);
+
+		\PRAutoBlogger_Run_Stage_State::fail( 'run-1', 'draft', '', 'idea:abc' );
+		\PRAutoBlogger_Run_Stage_State::fail_open_for_item( 'run-1', 'idea:abc' );
+
+		$this->assertStringContainsString( "status != 'done'", $this->queries[0] );
+		$this->assertStringContainsString( "status IN ('pending','running')", $this->queries[1] );
+	}
+
+	/**
+	 * Without the table (half-migrated site) every method degrades to a
+	 * harmless no-op/false/null — never a fatal.
+	 */
+	public function test_no_table_degrades_to_noops(): void {
+		$this->wpdb->method( 'get_var' )->willReturn( null ); // SHOW TABLES miss.
+		$this->wpdb->expects( $this->never() )->method( 'query' );
+
+		\PRAutoBlogger_Run_Stage_State::start( 'run-1', 'draft' );
+		\PRAutoBlogger_Run_Stage_State::done( 'run-1', 'draft', '', '', 'output' );
+		\PRAutoBlogger_Run_Stage_State::fail( 'run-1', 'draft' );
+		$this->assertFalse( \PRAutoBlogger_Run_Stage_State::is_done( 'run-1', 'draft' ) );
+		$this->assertNull( \PRAutoBlogger_Run_Stage_State::get_output( 'run-1', 'draft' ) );
+	}
+}

--- a/tests/unit/Core/StageDisplayMapTest.php
+++ b/tests/unit/Core/StageDisplayMapTest.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Tests for PRAutoBlogger_Stage_Display_Map.
+ *
+ * Locks the stage vocabulary contract from the Pipeline v2 Phase 1 brief:
+ * every historical prod stage value (incl. the image stages) and every
+ * Pipeline v2 stage value must render, carry a default agent role, and —
+ * where applicable — map to a prompt-registry key. Unknown values must
+ * humanize, never render blank.
+ *
+ * @package PRAutoBlogger\Tests\Core
+ */
+
+namespace PRAutoBlogger\Tests\Core;
+
+use PRAutoBlogger\Tests\BaseTestCase;
+
+class StageDisplayMapTest extends BaseTestCase {
+
+	/**
+	 * Every historical stage value observed on prod (90d window, 2026-06-11)
+	 * plus the code-only opik_eval_judge must be known to the map.
+	 */
+	public function test_all_historical_stages_are_known(): void {
+		$historical = array(
+			'analysis',
+			'outline',
+			'draft',
+			'polish',
+			'review',
+			'llm_research',
+			'image_a',
+			'image_b',
+			'image_prompt_rewrite',
+			'opik_eval_judge',
+		);
+		foreach ( $historical as $stage ) {
+			$this->assertTrue(
+				\PRAutoBlogger_Stage_Display_Map::is_known( $stage ),
+				"Historical stage '{$stage}' must be in the display map."
+			);
+			$this->assertNotSame( '', \PRAutoBlogger_Stage_Display_Map::label( $stage ) );
+		}
+	}
+
+	/**
+	 * The Pipeline v2 vocabulary must be known to the map.
+	 */
+	public function test_all_v2_stages_are_known(): void {
+		foreach ( array( 'research', 'curate', 'draft', 'editorial', 'seo', 'publish' ) as $stage ) {
+			$this->assertTrue( \PRAutoBlogger_Stage_Display_Map::is_known( $stage ) );
+		}
+	}
+
+	/**
+	 * Unknown stages humanize instead of rendering blank.
+	 */
+	public function test_unknown_stage_humanizes(): void {
+		$this->assertSame(
+			'Some Future Stage',
+			\PRAutoBlogger_Stage_Display_Map::label( 'some_future_stage' )
+		);
+		$this->assertFalse( \PRAutoBlogger_Stage_Display_Map::is_known( 'some_future_stage' ) );
+		$this->assertNull( \PRAutoBlogger_Stage_Display_Map::default_agent_role( 'some_future_stage' ) );
+		$this->assertNull( \PRAutoBlogger_Stage_Display_Map::default_prompt_key( 'some_future_stage' ) );
+	}
+
+	/**
+	 * Stage → default agent role mapping (stamped on generation_log rows
+	 * when the call site does not pass a role).
+	 */
+	public function test_default_agent_roles(): void {
+		$this->assertSame( 'analyst', \PRAutoBlogger_Stage_Display_Map::default_agent_role( 'analysis' ) );
+		$this->assertSame( 'writer', \PRAutoBlogger_Stage_Display_Map::default_agent_role( 'draft' ) );
+		$this->assertSame( 'writer', \PRAutoBlogger_Stage_Display_Map::default_agent_role( 'polish' ) );
+		$this->assertSame( 'editor', \PRAutoBlogger_Stage_Display_Map::default_agent_role( 'review' ) );
+		$this->assertSame( 'researcher', \PRAutoBlogger_Stage_Display_Map::default_agent_role( 'llm_research' ) );
+		$this->assertSame( 'illustrator', \PRAutoBlogger_Stage_Display_Map::default_agent_role( 'image_a' ) );
+		$this->assertSame( 'illustrator', \PRAutoBlogger_Stage_Display_Map::default_agent_role( 'image_prompt_rewrite' ) );
+	}
+
+	/**
+	 * Stage → primary prompt-registry key (resolves the pinned
+	 * prompt_version stamped on rows). The image keys are the composer-PR
+	 * seam and must not change without coordinating on the thread.
+	 */
+	public function test_default_prompt_keys(): void {
+		$this->assertSame( 'analysis.system', \PRAutoBlogger_Stage_Display_Map::default_prompt_key( 'analysis' ) );
+		$this->assertSame( 'content.outline', \PRAutoBlogger_Stage_Display_Map::default_prompt_key( 'outline' ) );
+		$this->assertSame( 'content.draft', \PRAutoBlogger_Stage_Display_Map::default_prompt_key( 'draft' ) );
+		$this->assertSame( 'content.polish', \PRAutoBlogger_Stage_Display_Map::default_prompt_key( 'polish' ) );
+		$this->assertSame( 'editor.system', \PRAutoBlogger_Stage_Display_Map::default_prompt_key( 'review' ) );
+		$this->assertSame( 'research.system', \PRAutoBlogger_Stage_Display_Map::default_prompt_key( 'llm_research' ) );
+		$this->assertSame( 'image.style_template', \PRAutoBlogger_Stage_Display_Map::default_prompt_key( 'image_a' ) );
+		$this->assertSame( 'image.style_template', \PRAutoBlogger_Stage_Display_Map::default_prompt_key( 'image_b' ) );
+		$this->assertSame( 'image.rewriter_system', \PRAutoBlogger_Stage_Display_Map::default_prompt_key( 'image_prompt_rewrite' ) );
+	}
+}

--- a/tests/unit/Providers/OpenRouterPricingTest.php
+++ b/tests/unit/Providers/OpenRouterPricingTest.php
@@ -177,4 +177,89 @@ class OpenRouterPricingTest extends BaseTestCase {
         // At least some models should be present.
         $this->assertGreaterThan( 0, count( $models ) );
     }
+
+    /**
+     * Test a snapshot-suffixed response model ID resolves to the base model's price.
+     *
+     * OpenRouter sometimes returns a dated snapshot ID as the response model
+     * (e.g. 'deepseek/deepseek-v4-flash-20260423' for a
+     * 'deepseek/deepseek-v4-flash' request). Pricing must strip the date
+     * suffix and bill at the base model's rate, not the conservative fallback.
+     */
+    public function test_estimate_cost_snapshot_suffix_resolves_to_base_model_price(): void {
+        Functions\when( 'get_transient' )->alias(
+            function ( string $key ) {
+                if ( 'prautoblogger_openrouter_models' === $key ) {
+                    return [
+                        [
+                            'id'             => 'deepseek/deepseek-v4-flash',
+                            'name'           => 'DeepSeek V4 Flash',
+                            'context_length' => 131072,
+                            'pricing'        => [ 'prompt' => 0.05, 'completion' => 0.20 ],
+                        ],
+                    ];
+                }
+                return false;
+            }
+        );
+
+        $pricing = new \PRAutoBlogger_OpenRouter_Pricing();
+
+        $base_cost     = $pricing->estimate_cost( 'deepseek/deepseek-v4-flash', 1000, 500 );
+        $snapshot_cost = $pricing->estimate_cost( 'deepseek/deepseek-v4-flash-20260423', 1000, 500 );
+
+        // Billed exactly like the base model: (1000 * 0.05 + 500 * 0.20) / 1M.
+        $this->assertSame( $base_cost, $snapshot_cost );
+        $this->assertEqualsWithDelta( 0.00015, $snapshot_cost, 1e-12 );
+
+        // And not at the conservative fallback rate (10/30 per M = 0.025 here).
+        $this->assertNotEquals( 0.025, $snapshot_cost );
+    }
+
+    /**
+     * Test an unknown model with no date suffix still gets the conservative estimate.
+     */
+    public function test_estimate_cost_unknown_model_without_suffix_uses_conservative_estimate(): void {
+        $pricing = new \PRAutoBlogger_OpenRouter_Pricing();
+        $cost = $pricing->estimate_cost( 'unknown/fake-model', 1000, 500 );
+
+        // Conservative fallback: (1000 * $10 + 500 * $30) / 1M.
+        $this->assertEqualsWithDelta( 0.025, $cost, 1e-12 );
+    }
+
+    /**
+     * Test a trailing digit run that is not an 8-digit date is never stripped.
+     *
+     * 'foo-202612345' has nine trailing digits — even with 'foo' and 'foo-2'
+     * registered, no stripping may occur and the conservative estimate applies.
+     */
+    public function test_estimate_cost_non_date_suffix_is_not_stripped(): void {
+        Functions\when( 'get_transient' )->alias(
+            function ( string $key ) {
+                if ( 'prautoblogger_openrouter_models' === $key ) {
+                    return [
+                        [
+                            'id'             => 'foo',
+                            'name'           => 'Foo',
+                            'context_length' => 8192,
+                            'pricing'        => [ 'prompt' => 0.01, 'completion' => 0.02 ],
+                        ],
+                        [
+                            'id'             => 'foo-2',
+                            'name'           => 'Foo 2',
+                            'context_length' => 8192,
+                            'pricing'        => [ 'prompt' => 0.01, 'completion' => 0.02 ],
+                        ],
+                    ];
+                }
+                return false;
+            }
+        );
+
+        $pricing = new \PRAutoBlogger_OpenRouter_Pricing();
+        $cost = $pricing->estimate_cost( 'foo-202612345', 1000, 500 );
+
+        // Nine trailing digits is not a snapshot date — conservative estimate applies.
+        $this->assertEqualsWithDelta( 0.025, $cost, 1e-12 );
+    }
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -31,6 +31,12 @@ $tables = array(
 	$prefix . 'generation_log',
 	$prefix . 'content_scores',
 	$prefix . 'event_log',
+	// Pipeline v2 substrate (v0.18.0 / db 1.2.0).
+	$prefix . 'prompts',
+	$prefix . 'run_sources',
+	$prefix . 'run_decisions',
+	$prefix . 'runs',
+	$prefix . 'run_stages',
 );
 
 foreach ( $tables as $table ) {
@@ -81,11 +87,14 @@ $wpdb->query(
 $hooks = array(
 	'prautoblogger_daily_generation',
 	'prautoblogger_collect_metrics',
+	'prautoblogger_reap_orphan_research_rows',
+	'prautoblogger_sync_runware_models',
+	'prautoblogger_manual_generation',
+	'prautoblogger_generate_queued_article',
+	'prautoblogger_generate_from_idea',
+	'prautoblogger_opik_dispatch',
 );
 
 foreach ( $hooks as $hook ) {
-	$timestamp = wp_next_scheduled( $hook );
-	if ( false !== $timestamp ) {
-		wp_unschedule_event( $timestamp, $hook );
-	}
+	wp_clear_scheduled_hook( $hook );
 }


### PR DESCRIPTION
> **Rebase note (2026-06-11):** rebased onto `6de8cf2` (PR #152 — deterministic image composer, released as **v0.17.0**). This PR is therefore **v0.18.0** now: plugin header/constant, CHANGELOG section (sits above 0.17.0), seed flag `prautoblogger_migrated_prompt_seed_v0180`, seed author `seed:v0.18.0`, and the ARCHITECTURE decision renumbered **#21 → #22** (composer took #21). Conflicts resolved against the post-#152 code: batch cost-reservation re-applied inside the restructured `class-image-pipeline.php` (same three seams: reserve before dispatch / release on dispatch failure / settle to actuals); doc/settings merges are disjoint-region splices. `image.*` registry seed sources verified byte-identical on new main (`class-image-prompt-builder.php` blob unchanged; style-template constant untouched by #152). db stays 1.2.0 (composer added no schema). Also flagging per QA P2: `includes/class-prautoblogger.php` grew 364→387 across commits 4–5. History rewrite of this branch was the requested rebase; QA re-review against the new head SHA required before merge.

## What changed

Pipeline v2 **Phase 1 substrate**, built on the current pipeline with **no behavior change** to the Economy (single-pass) and multi-step publish paths. Six commits, four workstreams (brief: `convo/prautoblogger/threads/2026-06-pipeline-v2-phase1/01-cto-handoff.md`; plan reply with the full brief-vs-code contradiction list: seq 2 on that thread):

1. **Schema v1.2.0** (`809e717`) — five new dbDelta-idempotent tables (`wp_prautoblogger_prompts`, `run_sources`, `run_decisions`, `runs`, `run_stages`); additive nullable `agent_role` + `prompt_version` on `generation_log`; `Stage_Display_Map` (historical + image + v2 stage vocabulary, humanizing fallback); uninstall covers all new tables + every cron hook; ARCHITECTURE `edit`→`polish` canonicalization.
2. **Versioned prompt registry** (`1b04809`) — all pipeline prompt copy (content/analysis/editor/research + the **illustration rewriter prompt and image Style Template**, i.e. the composer-PR seam keys `image.rewriter_system` / `image.style_template`) seeded as immutable v1 from the v0.16.0 texts; one active version per key; changes create versions, never mutate. Call sites render through `Prompt_Registry` with a **byte-identical in-code fallback** (no fatals on half-migrated state). Runs pin active versions at start; every generation_log row is stamped with `prompt_version` + `agent_role`.
3. **Per-run cost governor** (`04f09f5`) — reserve-before-call against the run ledger via one atomic conditional UPDATE (the #10 lock discipline); estimates from the #18 pricing chain; guard lives **inside `send_chat_completion`** so every text-LLM path is covered; the image `curl_multi` batch reserves its summed estimate before dispatch; settle-to-actuals after each response. Breach → run `halted` (sticky) + overage recorded + un-dispatched queued articles aborted + "Halted runs" notice on the Review Queue. Ceiling = `prautoblogger_per_run_cost_ceiling_usd` setting (default $0.50, 0 = disabled). Monthly cap + AI Gateway untouched.
4. **Run state machine + idempotency** (`ed8ec94`) — per-stage state keyed `run_id + stage + agent_role + item_key`; done stages snapshot output and are reused on re-entry (never re-charged); post creation keyed by `_prautoblogger_run_id` + new `_prautoblogger_idea_hash` (check-before-insert) so retries cannot duplicate posts; `Run_Reaper` rides the existing #19 cron (stuck stages/runs → `failed`, queryable as "incomplete"); `request_json` + stage-payload retention from the new setting (default 14d); `Audit_Writer` records editorial verdicts (run_decisions) + kept sources (run_sources) for new runs.
5. **Half-migrated-state hardening** (`1062af2`) — generation_log inserts retry without the new columns when missing; db-version self-heal also runs on cron requests (after a deploy, cron can fire before any admin visit).
6. **Snapshot-ID pricing fix** (`e6e3f85`) — OpenRouter pricing resolves dated snapshot model IDs (`-YYYYMMDD`) to the base model price before the conservative-estimate fallback (exact-match-first; non-date suffixes never stripped). Kills the phantom $0.58/run booking that would have eaten the per-run ceiling and the monthly gate.

Version 0.18.0 + `prautoblogger_db_version` 1.2.0 (self-healing auto-migration). CHANGELOG/ARCHITECTURE/CONVENTIONS updated in the same commits as their changes.

## Why

CEO-approved pipeline rebuild, Phase 1 of the plan of record (`convo/cpo/threads/2026-06-prautoblogger-pipeline-redesign/03-cto-revised-brief.md` §4.1–4.4): tune prompts without deploys + run comparability (registry/pinning), per-run spend enforcement (only the monthly cap existed; `get_current_run_cost()` was unguarded), duplicate-post/double-charge elimination on the chained-cron architecture, and the audit substrate Phase 2's 6-stage Authority flow drops into without another migration.

## Risk flags

- **Schema:** 5 new tables + 2 additive nullable columns; dbDelta idempotent; no existing column/index touched; no collision with the legacy `wp_autoblogger_*` orphans. Uninstall purges everything new.
- **Prompt parity is proven, not assumed:** a parity harness rendered every old builder (from `d559fc5`) against the new registry fallbacks across niche/instructions/performance branches — 17/17 byte-identical (single_pass/outline/polish/editor.system also locked as unit tests).
- **Behavioral deltas (intentional, additive):** per-run ceiling **enforces** at $0.50/run default (multi-step baseline ≈ $0.04/post — 12× headroom; set 0 to disable); image_prompt_rewrite rows now carry prompt_version (stamping only — their `run_id` stays NULL exactly as before, so log linking/amortization are unaffected); editorial verdicts + kept sources now also write to the audit tables.
- **Cost impact:** none on LLM spend (same calls, same prompts byte-for-byte); +1 ledger UPDATE per call (reserve) + 1 (settle) + state upserts per stage — trivial vs 14+ LLM calls/article.
- **300-line rule:** all 13 new classes < 300. Files already over on main and grown slightly here, flagged honestly: `class-executor.php` 329→351, `class-image-pipeline.php` 279→297 vs the post-#152 restructure on main (net +18 governor lines; its future split stays with the image workstream). Brought back under: `pipeline-runner` 306→271, `content-generator` 301→273, `cost-tracker` →290, `activator` →292.
- **NSFW single-image retries** are not batch-reserved (single calls outside the batch path, ~$0.0006); flagged for the composer PR.
- **`log_image_generation` still hardcodes `provider='cloudflare-workers-ai'`** (pre-existing mislabel since v0.10.0) — left for the composer PR which owns image logging.
- **Quorum logic is NOT built** (Phase 2) — only the `agent_role`/`item_key` schema dimensions exist.

## Test plan

Ran locally (PHP 8.3.9): `php -l` on every touched file; `phpcs --standard=phpcs.xml` clean over the CI scope (`includes/ prautoblogger.php uninstall.php`); PHPUnit 247 tests — 24 new (StageDisplayMap, PromptRegistry fallback-parity, CostGovernor reserve/breach/settle, RunStageState keys/sticky-done, RunReaper retention/sweeps) all green; the 15 errors + 1 failure that remain are **pre-existing on main `d559fc5`** (PHP 8.3 float-precision in Runware support + Image_Pipeline dynamic-property deprecations), verified by running the suite on a clean checkout. Plus the 17-check prompt parity harness above.

After merge, on **staging** (prod generation is idle since 2026-05-15; do not gate on prod cron):
1. Activate → confirm 5 tables exist, `prautoblogger_db_version` = 1.2.0, prompts table has 12 v1 rows (`author='seed:v0.18.0'`).
2. Run single-pass AND multi-step generations → posts publish exactly as before; every new generation_log row carries `prompt_version` + `agent_role`; runs row ends `done` with pins JSON.
3. Force ceiling to $0.0001 → run halts pre-dispatch, runs row `halted` + overage set, Review Queue shows the notice, no orphan gen_log rows, queued articles abort.
4. Kill a multi-article run mid-queue (deactivate plugin mid-run or kill PHP) → re-trigger → no duplicate post (idea-hash check), done stages not re-charged; after the reaper cron the run reads `failed`/"incomplete".
5. Confirm Economy/multi-step $/article vs the Phase-0 baseline doc (±model-price noise).

**Do not merge without the independent QA review against this SHA.**
