### PR TITLE
fix: restore 3 bootstrap constants dropped in v0.19.0 — admin 500 hotfix (v0.20.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to PRAutoBlogger will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Semantic Versioning](https://semver.org/).
 
+## [0.20.1] - 2026-06-12
+
+### Fixed
+- **Restore three bootstrap constants deleted by the v0.19.0 constants-block regression**
+  (`PRAUTOBLOGGER_DEFAULT_RUN_CEILING_USD` 0.50, `PRAUTOBLOGGER_DEFAULT_REQUEST_JSON_RETENTION_DAYS` 14,
+  `PRAUTOBLOGGER_DEFAULT_REASONING_MAX_TOKENS` 2048 — verbatim v0.18.3 values). PR #156 (v0.19.0)
+  dropped them from `prautoblogger.php`; the gap was latent because `tests/bootstrap.php` defines
+  its own fallbacks (CI green) and no exercised v0.19.x runtime path read them (prod reasoning
+  disabled). v0.20.0's activator defaults + run-state ceiling read them on the admin
+  migration path -> fatal 500 on all plugin admin pages immediately after the v0.20.0 deploy
+  (2026-06-12; front-of-site unaffected; hot-patched on prod within minutes, this commit makes
+  it canonical). Follow-up owed: CI guard asserting every referenced PRAUTOBLOGGER_* constant
+  is production-defined or defined()-guarded (maintenance thread).
+
 ## [0.20.0] - 2026-06-12
 
 ### Added

--- a/prautoblogger.php
+++ b/prautoblogger.php
@@ -9,7 +9,7 @@
  * Plugin Name:       PRAutoBlogger
  * Plugin URI:        https://peptiderepo.com/prautoblogger
  * Description:       Monitors social media for trending topics, generates SEO-friendly blog posts using AI, and publishes them on a daily schedule with full cost tracking and self-improvement metrics.
- * Version:           0.20.0
+ * Version:           0.20.1
  * Requires at least: 6.0
  * Requires PHP:      7.4
  * Author:            PeptideRepo
@@ -35,8 +35,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 | Defined here so every file in the plugin can reference paths, versions,
 | and limits without magic strings.
 */
-define( 'PRAUTOBLOGGER_VERSION', '0.20.0' );
+define( 'PRAUTOBLOGGER_VERSION', '0.20.1' );
 define( 'PRAUTOBLOGGER_DB_VERSION', '1.3.0' );
+define( 'PRAUTOBLOGGER_DEFAULT_RUN_CEILING_USD', 0.50 );
+define( 'PRAUTOBLOGGER_DEFAULT_REQUEST_JSON_RETENTION_DAYS', 14 );
+// v0.18.1: ceiling on "thinking" tokens per reasoning-enabled LLM call. The
+// request's completion budget (max_tokens) is RAISED by this amount so
+// reasoning can never consume the visible-content budget and return an empty
+// message (the 2026-06-11 empty-draft incident). SETTINGS-backed
+// (prautoblogger_reasoning_max_tokens); 0 disables the cap (pure effort mode).
+define( 'PRAUTOBLOGGER_DEFAULT_REASONING_MAX_TOKENS', 2048 );
 define( 'PRAUTOBLOGGER_PLUGIN_FILE', __FILE__ );
 define( 'PRAUTOBLOGGER_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PRAUTOBLOGGER_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## What
Restores PRAUTOBLOGGER_DEFAULT_RUN_CEILING_USD / _REQUEST_JSON_RETENTION_DAYS / _REASONING_MAX_TOKENS (verbatim v0.18.3 values + comments) to the constants block, version 0.20.1 + CHANGELOG.

## Why
Prod incident 2026-06-12 immediately after the v0.20.0 deploy: every plugin admin page 500 (Undefined constant at class-activator.php:71-72 via the db-migration admin hook). PR #156 (v0.19.0) deleted the trio; tests/bootstrap.php fallback defines masked it in CI; no exercised v0.19.x path read them (reasoning disabled on prod since the empty-draft mitigation). Front-of-site was unaffected throughout. Prod was hot-patched in place within minutes and functionally verified (board + dossier 200, edit surface rendering, db 1.3.0); this PR makes the fix canonical so main is deployable.

## Risk flags
Three restored define lines + version/CHANGELOG. None beyond that.

## Test plan
CI matrix; constants block now matches what prod is verified-running. Follow-up (maintenance thread): CI guard asserting every referenced PRAUTOBLOGGER_* constant is production-defined or defined()-guarded; QA checklist gains a constants-audit item.