### PR TITLE
fix: close M4 P2s — LIMIT 100 in get_run_io() + wpdb-null test (v0.27.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to PRAutoBlogger will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Semantic Versioning](https://semver.org/).
 
+## [0.27.1] - 2026-06-23
+
+### Fixed (M4 P2 cleanup)
+- **P2-1 (safety cap):** Added `LIMIT 100` to the `generation_log` query inside
+  `Gen_History_Query::get_run_io()` (`includes/admin/class-gen-history-query.php`).
+  A run has ~6–10 stage rows in practice; 100 is a generous safety cap that prevents
+  a pathological run with many log rows from blowing up the AJAX payload.
+- **P2-2 (test):** Implemented the declared-but-missing
+  `test_get_page_returns_empty_when_wpdb_null()` test in
+  `tests/unit/Admin/GenHistoryQueryTest.php`. Confirms the `get_page()` null-wpdb
+  guard returns `array( 'rows' => array(), 'total' => 0 )`.
+
 ## [0.27.0] - 2026-06-23
 
 ### Fixed (QA P1/P2 sweep — post-3cd2843)

--- a/includes/admin/class-gen-history-query.php
+++ b/includes/admin/class-gen-history-query.php
@@ -160,7 +160,8 @@ class PRAutoBlogger_Gen_History_Query {
 					request_json, response_status, error_message, created_at
 				 FROM {$log_table}
 				 WHERE run_id = %s
-				 ORDER BY id ASC",
+				 ORDER BY id ASC
+				 LIMIT 100", // Safety cap: a run has ~6-10 stage rows; 100 is generous.
 				$run_id
 			),
 			ARRAY_A

--- a/prautoblogger.php
+++ b/prautoblogger.php
@@ -9,7 +9,7 @@
  * Plugin Name:       PRAutoBlogger
  * Plugin URI:        https://peptiderepo.com/prautoblogger
  * Description:       Monitors social media for trending topics, generates SEO-friendly blog posts using AI, and publishes them on a daily schedule with full cost tracking and self-improvement metrics.
- * Version:           0.27.0
+ * Version:           0.27.1
  * Requires at least: 6.0
  * Requires PHP:      7.4
  * Author:            PeptideRepo
@@ -35,7 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 | Defined here so every file in the plugin can reference paths, versions,
 | and limits without magic strings.
 */
-define( 'PRAUTOBLOGGER_VERSION', '0.27.0' );
+define( 'PRAUTOBLOGGER_VERSION', '0.27.1' );
 define( 'PRAUTOBLOGGER_DB_VERSION', '1.4.0' );
 define( 'PRAUTOBLOGGER_DEFAULT_RUN_CEILING_USD', 0.50 );
 define( 'PRAUTOBLOGGER_DEFAULT_REQUEST_JSON_RETENTION_DAYS', 14 );

--- a/tests/unit/Admin/GenHistoryQueryTest.php
+++ b/tests/unit/Admin/GenHistoryQueryTest.php
@@ -194,4 +194,29 @@ class GenHistoryQueryTest extends BaseTestCase {
 		$this->assertSame( 20, \PRAutoBlogger_Gen_History_Query::PAGE_SIZE );
 		$this->assertSame( 100, \PRAutoBlogger_Gen_History_Query::PAGE_SIZE_MAX );
 	}
+
+	// -----------------------------------------------------------------------
+	// get_page() early return
+	// -----------------------------------------------------------------------
+
+	/**
+	 * When $wpdb is null, get_page() returns the empty guard shape immediately.
+	 *
+	 * @return void
+	 */
+	public function test_get_page_returns_empty_when_wpdb_null(): void {
+		// Force the global to null to exercise the guard at the top of get_page().
+		$prev_wpdb          = $GLOBALS['wpdb'] ?? null;
+		$GLOBALS['wpdb']    = null;
+
+		try {
+			$query  = new \PRAutoBlogger_Gen_History_Query();
+			$result = $query->get_page();
+		} finally {
+			// Always restore so later tests are unaffected.
+			$GLOBALS['wpdb'] = $prev_wpdb;
+		}
+
+		$this->assertSame( array( 'rows' => array(), 'total' => 0 ), $result );
+	}
 }


### PR DESCRIPTION
## What

Closes the two open non-blocking P2s from the M4 Generation History milestone.

**P2-1 — LIMIT cap in `get_run_io()`** (`includes/admin/class-gen-history-query.php`)

The `generation_log` query inside `Gen_History_Query::get_run_io()` had no LIMIT. A run has ~6–10 stage rows in practice; without a cap, a pathological run with many log rows could blow up the AJAX payload. Added `LIMIT 100` with a brief comment. `ORDER BY id ASC` and the `$wpdb->prepare` arg handling (`%s` / `$run_id`) are unchanged.

**P2-2 — Implement missing test** (`tests/unit/Admin/GenHistoryQueryTest.php`)

The file preamble declared "(4) get_page() returns empty result when wpdb is null" but the 6th test only checked constants. `test_get_page_returns_empty_when_wpdb_null()` now exercises the real null guard in `get_page()`, asserting the exact return shape `array( 'rows' => array(), 'total' => 0 )`. Saves/restores `$GLOBALS['wpdb']` in a `finally` block to avoid leaking state.

## Why

M4 shipped with QA `APPROVE-WITH-P2-NOTES`; these two items were explicitly deferred. Closing them now keeps the debt ledger clean before Phase 2b begins.

## Risk

**Low.** Both changes are entirely internal:
- The LIMIT 100 cap is unreachable in normal operation (6–10 rows per run) and applies only to a single AJAX drill-down endpoint.
- The test addition has zero production code impact; it only exercises an existing early-return guard.

No schema changes, no admin UI changes, no ARCHITECTURE/IA updates required.

## Test plan

1. CI: PHPUnit unit suite must stay green (new test covers the null-wpdb path; existing 6 tests unchanged).
2. PHP Lint: `php -l` clean on both modified files.
3. PHPCS: no new violations (only SQL whitespace-equivalent change + pure test addition).
4. Manual smoke: on staging, open the Generation History page → click any run row → inspector populates stage I/O as before.